### PR TITLE
fix: makefile uv pip + preferences Decimal serialization + flaky test repairs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,8 +64,9 @@ deploy-athena:
 package-scraper:
 	@echo ">> Packaging scraper Lambda..."
 	@mkdir -p build
-	@cd lambdas/scraper && pip install -r requirements.txt -t ./package --quiet 2>/dev/null || true
-	@cd lambdas/scraper && cp -r . ./package/ 2>/dev/null || true
+	@rm -rf lambdas/scraper/package
+	@uv pip install -r lambdas/scraper/requirements.txt --target lambdas/scraper/package --quiet
+	@cp lambdas/scraper/*.py lambdas/scraper/package/
 	@cp facilities.py lambdas/scraper/package/
 	@cd lambdas/scraper/package && zip -qr ../../../build/scraper.zip .
 	@echo "   build/scraper.zip ready"
@@ -73,8 +74,9 @@ package-scraper:
 package-preferences:
 	@echo ">> Packaging preferences Lambda..."
 	@mkdir -p build
-	@cd lambdas/preferences && pip install -r requirements.txt -t ./package --quiet 2>/dev/null || true
-	@cd lambdas/preferences && cp -r . ./package/ 2>/dev/null || true
+	@rm -rf lambdas/preferences/package
+	@uv pip install -r lambdas/preferences/requirements.txt --target lambdas/preferences/package --quiet
+	@cp lambdas/preferences/*.py lambdas/preferences/package/
 	@cp facilities.py lambdas/preferences/package/
 	@cd lambdas/preferences/package && zip -qr ../../../build/preferences.zip .
 	@echo "   build/preferences.zip ready"
@@ -82,8 +84,9 @@ package-preferences:
 package-notifications:
 	@echo ">> Packaging notifications Lambda..."
 	@mkdir -p build
-	@cd lambdas/notifications && pip install -r requirements.txt -t ./package --quiet 2>/dev/null || true
-	@cd lambdas/notifications && cp -r . ./package/ 2>/dev/null || true
+	@rm -rf lambdas/notifications/package
+	@uv pip install -r lambdas/notifications/requirements.txt --target lambdas/notifications/package --quiet
+	@cp lambdas/notifications/*.py lambdas/notifications/package/
 	@cp facilities.py lambdas/notifications/package/
 	@cd lambdas/notifications/package && zip -qr ../../../build/notifications.zip .
 	@echo "   build/notifications.zip ready"
@@ -91,8 +94,9 @@ package-notifications:
 package-newsletter:
 	@echo ">> Packaging newsletter Lambda..."
 	@mkdir -p build
-	@cd lambdas/newsletter && pip install -r requirements.txt -t ./package --quiet 2>/dev/null || true
-	@cd lambdas/newsletter && cp -r . ./package/ 2>/dev/null || true
+	@rm -rf lambdas/newsletter/package
+	@uv pip install -r lambdas/newsletter/requirements.txt --target lambdas/newsletter/package --quiet
+	@cp lambdas/newsletter/*.py lambdas/newsletter/package/
 	@cp facilities.py lambdas/newsletter/package/
 	@cp lambdas/notifications/matcher.py lambdas/newsletter/package/
 	@cd lambdas/newsletter/package && zip -qr ../../../build/newsletter.zip .
@@ -101,16 +105,18 @@ package-newsletter:
 package-feedback:
 	@echo ">> Packaging feedback Lambda..."
 	@mkdir -p build
-	@cd lambdas/feedback && pip install -r requirements.txt -t ./package --quiet 2>/dev/null || true
-	@cd lambdas/feedback && cp -r . ./package/ 2>/dev/null || true
+	@rm -rf lambdas/feedback/package
+	@uv pip install -r lambdas/feedback/requirements.txt --target lambdas/feedback/package --quiet
+	@cp lambdas/feedback/*.py lambdas/feedback/package/
 	@cd lambdas/feedback/package && zip -qr ../../../build/feedback.zip .
 	@echo "   build/feedback.zip ready"
 
 package-harvard-scraper:
 	@echo ">> Packaging harvard-scraper Lambda..."
-	@mkdir -p build lambdas/harvard-scraper/package
-	@cd lambdas/harvard-scraper && pip install -r requirements.txt -t ./package --quiet 2>/dev/null || true
-	@cd lambdas/harvard-scraper && cp *.py ./package/
+	@mkdir -p build
+	@rm -rf lambdas/harvard-scraper/package
+	@uv pip install -r lambdas/harvard-scraper/requirements.txt --target lambdas/harvard-scraper/package --quiet
+	@cp lambdas/harvard-scraper/*.py lambdas/harvard-scraper/package/
 	@cp facilities.py lambdas/harvard-scraper/package/
 	@cd lambdas/harvard-scraper/package && zip -qr ../../../build/harvard-scraper.zip .
 	@echo "   build/harvard-scraper.zip ready"
@@ -195,8 +201,9 @@ deploy-festival-dynamo:
 package-festival-preferences:
 	@echo ">> Packaging festival-preferences Lambda..."
 	@mkdir -p build
-	@cd lambdas/festival-preferences && pip install -r requirements.txt -t ./package --quiet 2>/dev/null || true
-	@cd lambdas/festival-preferences && cp -r . ./package/ 2>/dev/null || true
+	@rm -rf lambdas/festival-preferences/package
+	@uv pip install -r lambdas/festival-preferences/requirements.txt --target lambdas/festival-preferences/package --quiet
+	@cp lambdas/festival-preferences/*.py lambdas/festival-preferences/package/
 	@cp festivals.py lambdas/festival-preferences/package/
 	@cd lambdas/festival-preferences/package && zip -qr ../../../build/festival-preferences.zip .
 	@echo "   build/festival-preferences.zip ready"

--- a/lambdas/preferences/handler.py
+++ b/lambdas/preferences/handler.py
@@ -22,6 +22,7 @@ import os
 import re
 import uuid
 from datetime import datetime, timedelta, timezone
+from decimal import Decimal
 from typing import Optional
 from zoneinfo import ZoneInfo
 
@@ -85,11 +86,19 @@ CORS_HEADERS = {
 }
 
 
+class _DecimalEncoder(json.JSONEncoder):
+    """Convert DynamoDB Decimal values to int/float for JSON serialization."""
+    def default(self, o):
+        if isinstance(o, Decimal):
+            return int(o) if o == int(o) else float(o)
+        return super().default(o)
+
+
 def _ok(body, status=200):
     return {
         "statusCode": status,
         "headers": CORS_HEADERS,
-        "body": json.dumps({"data": body}),
+        "body": json.dumps({"data": body}, cls=_DecimalEncoder),
     }
 
 

--- a/tests/test_newsletter.py
+++ b/tests/test_newsletter.py
@@ -47,6 +47,7 @@ SES_FROM_EMAIL = "bot@tennis.test"
 
 # Fixed "today" = Tuesday 2026-03-10 → next Monday = 2026-03-16
 FIXED_TODAY = datetime.date(2026, 3, 10)
+FIXED_NOW = datetime.datetime(2026, 3, 10, 8, 0)
 
 
 # ---------------------------------------------------------------------------
@@ -86,7 +87,17 @@ def dynamo(monkeypatch):
         def today(cls):
             return FIXED_TODAY
 
+    # Also pin datetime.datetime.now so matcher._is_past_slot treats
+    # the seeded week (2026-03-16 …) as being in the present, not the past.
+    class FakeDatetime(datetime.datetime):
+        @classmethod
+        def now(cls, tz=None):
+            if tz is None:
+                return FIXED_NOW
+            return FIXED_NOW.replace(tzinfo=tz)
+
     monkeypatch.setattr(datetime, "date", FakeDate)
+    monkeypatch.setattr(datetime, "datetime", FakeDatetime)
 
     with mock_aws():
         client = boto3.client("dynamodb", region_name=REGION)

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -746,7 +746,13 @@ class TestDedup:
 
 
 class TestEmailBuilder:
-    def test_subject_single_court(self):
+    def test_subject_single_court(self, monkeypatch):
+        # Pin the random prefix so the 'courts' assertion isn't broken by
+        # prefixes that happen to contain the word 'courts' themselves
+        # (e.g. "New courts on the radar!").
+        import random
+        monkeypatch.setattr(random, "choice", lambda seq: "Court alert!")
+
         from email_builder import build_notification_email
 
         matches = [

--- a/tests/test_preferences.py
+++ b/tests/test_preferences.py
@@ -1229,3 +1229,48 @@ class TestGolfPreferences:
         )
         assert resp["statusCode"] == 400
         assert "does not support sport" in _body(resp)["error"]
+
+    def test_list_preferences_serializes_decimal_minSpots(self, dynamo):
+        """Regression: GET preferences must serialize DynamoDB Decimal values.
+
+        DynamoDB returns numeric fields (e.g. golf minSpots) as Decimal. A
+        previous version of _ok() called plain json.dumps() which raised
+        TypeError on Decimal, causing "Failed to load preferences" in the UI
+        for any user with a golf preference.
+        """
+        import handler as h
+
+        _register_user("golfer-decimal@example.com", "GolferDecimal")
+        create = h.lambda_handler(
+            _event(
+                "POST",
+                "/users/{userId}/preferences",
+                body={
+                    "facilityId": "onsoy",
+                    "sport": "golf",
+                    "dates": ["saturday"],
+                    "timeFrom": "07:00",
+                    "timeTo": "12:00",
+                    "minSpots": 2,
+                },
+                path_params={"userId": "golfer-decimal@example.com"},
+            ),
+            None,
+        )
+        assert create["statusCode"] == 201
+
+        # GET re-reads from DynamoDB, which returns minSpots as Decimal.
+        # Without _DecimalEncoder this raises TypeError inside json.dumps.
+        resp = h.lambda_handler(
+            _event(
+                "GET",
+                "/users/{userId}/preferences",
+                path_params={"userId": "golfer-decimal@example.com"},
+            ),
+            None,
+        )
+        assert resp["statusCode"] == 200
+        items = _body(resp)["data"]
+        assert len(items) == 1
+        assert items[0]["minSpots"] == 2
+        assert isinstance(items[0]["minSpots"], int)


### PR DESCRIPTION
## Summary

This branch was rebased onto the post-#126 main and ended up collecting four related fixes that together make `make deploy-all` plus the full test suite green on macOS.

### 1. Makefile — `uv pip install` for all lambda packaging targets
Replaces `pip install -r requirements.txt -t ./package --quiet 2>/dev/null || true` with `uv pip install --target …` across 7 packaging targets. The old pattern silently swallowed PEP 668 failures on macOS and produced zero-dependency zips that crashed at Lambda cold-start with `ModuleNotFoundError: requests`. Also drops the `cp -r . ./package/` self-recursive copy bug (left stray `package/package/package/…` trees on disk) in favour of an explicit `cp lambdas/<name>/*.py`. `package-golf-scraper` already used this pattern — this PR extends it to the rest.

### 2. Preferences lambda — DynamoDB Decimal serialization
`boto3` returns number attributes as `Decimal` objects; `json.dumps` can't handle them, so API responses containing numeric fields (notably the lists) crashed. Adds a `_DecimalEncoder` and wires it through the JSON serializer. Regression test included.

### 3. test_newsletter — pin `datetime.datetime.now` in the fixture
The existing fixture pinned `datetime.date.today` to 2026-03-10 so the computed newsletter week is always `2026-03-16…22`, but it did NOT pin `datetime.datetime.now`. `matcher._is_past_slot()` uses `datetime.datetime.now(OSLO_TZ)`, so as soon as real time passed the fixed week, any seeded slot was filtered out as "past" and the three "sends email" tests silently regressed. Extended the fixture with a `FakeDatetime` whose `.now()` returns a `FIXED_NOW` pinned to the same day as `FIXED_TODAY`.

### 4. test_notifications::test_subject_single_court — deterministic subject prefix
The test asserts `'courts'` (plural) is not in the subject for a single-court email, but `_SUBJECT_PREFIXES` contains two entries that themselves include the word `'courts'` (`"New courts on the radar!"`, `"Fresh courts just dropped!"`), making it flaky at ~29% failure per run. Patched via `monkeypatch.setattr(random, "choice", lambda seq: "Court alert!")`.

## Test plan

- [x] All 7 lambda packaging targets build cleanly from scratch on macOS (uv 0.11.6)
- [x] Full test suite green 3× in a row:
      ```
      test_e2e_pipeline.py       8 passed
      test_feedback.py          17 passed
      test_harvard_scraper.py   11 passed
      test_highscores.py        16 passed
      test_newsletter.py        18 passed
      test_notifications.py     44 passed
      test_oslobooking_scraper 13 passed (1 integration deselected)
      test_preferences.py       54 passed
      test_scraper.py           27 passed
      ```
- [x] Rebased onto main post-#126 squash; merge state CLEAN
- [ ] Post-merge: `make deploy-all` to redeploy preferences lambda with the Decimal fix

## Known non-goals (deliberately excluded)

- `test_golf_scraper.py` + `test_golf_integration.py` + `test_harvard_integration.py` still have pre-existing module-shadow import collisions that are unrelated to this PR. Those live on your 36-commits-ahead local main as `97ea5be fix: use importlib for harvard-scraper test imports to avoid module collisions` and should ride on their own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)