### PR TITLE
feat(golf-scraper): Vardenlab MCP data source for member-view tee times

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -175,20 +175,25 @@ deploy-harvard-scraper: package-harvard-scraper
 
 package-golf-scraper:
 	@echo ">> Packaging golf-scraper Lambda..."
-	@rm -rf lambdas/golf-scraper/package lambdas/golf-scraper/build
-	@mkdir -p lambdas/golf-scraper/build
-	@uv pip install -r lambdas/golf-scraper/requirements.txt --target lambdas/golf-scraper/package
-	@powershell -Command "Compress-Archive -Path 'lambdas/golf-scraper/package/*' -DestinationPath 'lambdas/golf-scraper/build/function.zip' -Force"
-	@powershell -Command "Compress-Archive -Path 'lambdas/golf-scraper/handler.py','lambdas/golf-scraper/scraper.py','lambdas/golf-scraper/parser.py' -DestinationPath 'lambdas/golf-scraper/build/function.zip' -Update"
-	@cp facilities.py lambdas/golf-scraper/build/
-	@powershell -Command "Compress-Archive -Path 'lambdas/golf-scraper/build/facilities.py' -DestinationPath 'lambdas/golf-scraper/build/function.zip' -Update"
-	@echo "   lambdas/golf-scraper/build/function.zip ready"
+	@mkdir -p build
+	@rm -f build/golf-scraper.zip
+	@rm -rf lambdas/golf-scraper/package
+	@uv pip install -r lambdas/golf-scraper/requirements.txt \
+		--target lambdas/golf-scraper/package \
+		--python-platform x86_64-manylinux2014 \
+		--python-version 3.11 \
+		--only-binary=:all: \
+		--quiet
+	@cp lambdas/golf-scraper/*.py lambdas/golf-scraper/package/
+	@cp facilities.py lambdas/golf-scraper/package/
+	@cd lambdas/golf-scraper/package && zip -qr ../../../build/golf-scraper.zip .
+	@echo "   build/golf-scraper.zip ready"
 
 deploy-golf-scraper: package-golf-scraper
 	@echo ">> Deploying golf-scraper Lambda..."
 	@aws lambda update-function-code \
 		--function-name $(GOLF_SCRAPER_FN) \
-		--zip-file fileb://lambdas/golf-scraper/build/function.zip \
+		--zip-file fileb://$(PWD)/build/golf-scraper.zip \
 		--profile $(PROFILE) --region $(REGION) \
 		--query 'LastUpdateStatus' --output text
 

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -109,15 +109,46 @@ refresh, then a flood of `400 invalid_grant` interleaved with
 - Secret `golfbox-mcp-tokens` exists but its refresh token was burned by the
   storm (do not assume valid).
 
+## Root cause CONFIRMED — 2026-05-22 (supersedes the aud/IP hypothesis)
+
+The earlier guess (access-token `aud` mismatch / Vardenlab IP-binding) is
+**wrong**. CloudWatch for the 2026-05-21 05:56 run proves the MCP path works
+fine from Lambda:
+
+- `70039ca4` (invocation A): refresh OK 05:56:57 → `initialize` OK 05:56:59
+  (`session_id=None`) → **collected 874 slots across 3 facilities** before any
+  failure. 874 successful `tools/call`s from an AWS IP ⇒ token, audience, AND
+  IP are all fine. `session_id=None` is also fine — Vardenlab's golfbox MCP is
+  stateless.
+- `52a1ee1d` (invocation B): started 05:57:55 — **60s after A, concurrently**.
+  Refresh OK 05:57:58.
+- A's first failure is at 05:57:59 — **1 second after B's refresh**. From then
+  A logs `400 invalid_grant` on every re-refresh; B gets `slots=0, errors=56`.
+
+**Actual root cause: a concurrency race on the rotating refresh token.**
+Vardenlab rotates the refresh token on every use and applies refresh-token
+**reuse detection** (using a rotated-away token revokes the whole token
+family, incl. access tokens). Two overlapping invocations share one stored RT:
+B rotated RT1→RT2; when A then re-refreshed with its stale in-memory RT1,
+Vardenlab revoked the entire family → both invocations' tokens died → the
+per-call "401 → re-refresh" retry amplified it into the 429 storm.
+
+Why two concurrent invocations at all: the schedule is `rate(20 minutes)` and a
+run takes ~100s, so scheduled runs never overlap. The 05-21 overlap was manual
+test invokes (05:56:55 and 05:57:55). In normal scheduled operation MCP would
+not have raced — but nothing *prevents* concurrency (manual invoke during a
+scheduled run, or any future faster schedule).
+
 ## STILL OPEN — do before flipping back to mcp source
-- [ ] Diagnose why `tools/call` returns 401 from the Lambda when the PoC on a
-      laptop (same code, same `session_id=None`) works. Prime suspects:
-      access-token `aud`/resource-audience mismatch, or Vardenlab binding the
-      token to the issuing IP. Decode the access-token JWT `aud` claim from a
-      fresh OAuth flow (don't burn a refresh just to test).
-- [ ] Re-provision the secret (run `scripts/golfbox_mcp_oauth_setup.py` or the
-      manual flow) once the 401 root cause is fixed.
+- [ ] **Set reserved concurrency = 1 on `golf-scraper`** — the real fix.
+      Serializes access to the rotating RT so invocations can't poison each
+      other. One-line infra change, no code change. The circuit breaker stays
+      as a secondary guardrail.
+- [ ] Re-provision the secret (run `scripts/golfbox_mcp_oauth_setup.py`) — the
+      RT family was revoked, so the stored token is dead and must be replaced.
+      Interactive (browser PKCE), run from a workstation.
 - [ ] Flip `GOLF_DATA_SOURCE=mcp` and monitor one run for
       `auth_failures=0, source=mcp` before trusting it.
-- NOTE: we may still be inside a Vardenlab rate-limit window — avoid hitting
-  the token endpoint until it clears.
+- Optional hardening: cache the access token (valid ~1h) in the secret so
+  warm+cold invocations reuse it and only refresh ~once/hour, cutting RT
+  rotations from ~72/day to ~24/day (each rotation is a fragility point).

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -69,3 +69,45 @@ Packaged and deployed via `aws lambda update-function-code`.
 - [ ] Verify a clean run completes and triggers notification emails
 - [ ] Monitor for a few cycles to confirm stability
 - [x] ~~Consider setting reserved concurrency to 1~~ — not possible (account `UnreservedConcurrentExecution` minimum of 10)
+
+---
+
+# Golf MCP auth-failure storm — 2026-05-21
+
+## Symptom
+First live `golf-scraper` run with `GOLF_DATA_SOURCE=mcp` produced
+`slots=0, errors=56, auth_failures=56`. CloudWatch showed one successful
+refresh, then a flood of `400 invalid_grant` interleaved with
+`429 too_many_requests` from `mcp.vardenlab.com`'s token endpoint.
+
+## Root cause (two compounding issues)
+1. **No circuit breaker.** The scraper iterates `facilities × DAYS_AHEAD`
+   (4 × 14 = 56). A broken OAuth chain fails identically for every
+   combination, so the handler retried all 56 — each a token refresh —
+   and Vardenlab rate-limited us (429). One bad token became 56 hammering
+   attempts.
+2. **Vardenlab rotates AND invalidates refresh tokens on every use.** The
+   first refresh succeeded and rotated the token, but `initialize` returned
+   no `Mcp-Session-Id` and the subsequent `tools/call` returned 401. The
+   client misread that 401 as an auth failure and refreshed again, burning
+   the just-rotated token → `invalid_grant` cascade.
+
+## Fixes applied
+- **Circuit breaker** (`handler.py`): abort the whole run once
+  `auth_failures >= MCP_AUTH_FAILURE_LIMIT` (default 3). One bad token now
+  costs a few log lines, not 56. Covered by `TestMcpAuthCircuitBreaker`.
+- **Immediate mitigation**: disabled `golf-scraper-schedule` EventBridge rule
+  and set `GOLF_DATA_SOURCE=scrape` to stop hammering the endpoint while the
+  remaining root cause (the `tools/call` 401 / session handling) is debugged.
+
+## STILL OPEN — do before re-enabling mcp source
+- [ ] Diagnose why `tools/call` returns 401 from the Lambda when the PoC on a
+      laptop (same code, same `session_id=None`) works. Prime suspects:
+      access-token `aud`/resource-audience mismatch, or Vardenlab binding the
+      token to the issuing IP. Decode the access-token JWT `aud` claim from a
+      fresh OAuth flow (don't burn a refresh just to test).
+- [ ] Re-provision the secret (current token likely burned by the storm).
+- [ ] Re-enable `golf-scraper-schedule` and flip `GOLF_DATA_SOURCE=mcp` only
+      after the 401 is understood and the breaker is deployed.
+- NOTE: we are likely still inside a Vardenlab rate-limit window — avoid
+  hitting the token endpoint until it clears.

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -96,18 +96,28 @@ refresh, then a flood of `400 invalid_grant` interleaved with
 - **Circuit breaker** (`handler.py`): abort the whole run once
   `auth_failures >= MCP_AUTH_FAILURE_LIMIT` (default 3). One bad token now
   costs a few log lines, not 56. Covered by `TestMcpAuthCircuitBreaker`.
-- **Immediate mitigation**: disabled `golf-scraper-schedule` EventBridge rule
-  and set `GOLF_DATA_SOURCE=scrape` to stop hammering the endpoint while the
-  remaining root cause (the `tools/call` 401 / session handling) is debugged.
+- **Immediate mitigation**: set `GOLF_DATA_SOURCE=scrape` and temporarily
+  disabled `golf-scraper-schedule` to stop hammering the token endpoint.
 
-## STILL OPEN — do before re-enabling mcp source
+## Current state (2026-05-21, end of session)
+- `GOLF_DATA_SOURCE=scrape` — Lambda runs the legacy GolfBox scrape path
+  (guest-view prices, the original issue, but functional). Verified manually:
+  3024 slots, 0 errors, 44s.
+- Circuit-breaker code **deployed**.
+- `golf-scraper-schedule` **re-enabled** at `rate(20 minutes)` — golf
+  notifications are flowing again on the scrape fallback.
+- Secret `golfbox-mcp-tokens` exists but its refresh token was burned by the
+  storm (do not assume valid).
+
+## STILL OPEN — do before flipping back to mcp source
 - [ ] Diagnose why `tools/call` returns 401 from the Lambda when the PoC on a
       laptop (same code, same `session_id=None`) works. Prime suspects:
       access-token `aud`/resource-audience mismatch, or Vardenlab binding the
       token to the issuing IP. Decode the access-token JWT `aud` claim from a
       fresh OAuth flow (don't burn a refresh just to test).
-- [ ] Re-provision the secret (current token likely burned by the storm).
-- [ ] Re-enable `golf-scraper-schedule` and flip `GOLF_DATA_SOURCE=mcp` only
-      after the 401 is understood and the breaker is deployed.
-- NOTE: we are likely still inside a Vardenlab rate-limit window — avoid
-  hitting the token endpoint until it clears.
+- [ ] Re-provision the secret (run `scripts/golfbox_mcp_oauth_setup.py` or the
+      manual flow) once the 401 root cause is fixed.
+- [ ] Flip `GOLF_DATA_SOURCE=mcp` and monitor one run for
+      `auth_failures=0, source=mcp` before trusting it.
+- NOTE: we may still be inside a Vardenlab rate-limit window — avoid hitting
+  the token endpoint until it clears.

--- a/facilities.py
+++ b/facilities.py
@@ -79,6 +79,7 @@ facilities = {
         "golfbox": {
             "resource_guid": "884D570B-7F66-4ECD-88E2-215E3B386422",
             "club_guid": "A85DA1E0-B469-4702-BDBC-4E8972EC50A9",
+            "mcp_slug": "onsoy_gk",
         },
     },
     "haga": {
@@ -88,6 +89,7 @@ facilities = {
         "golfbox": {
             "resource_guid": "E95F6988-C683-43F8-919C-7F835DBFAF27",
             "club_guid": "E0105CD4-744F-4323-9B70-426E833E2EE6",
+            "mcp_slug": "haga_gk",
         },
     },
     "grini": {
@@ -97,6 +99,7 @@ facilities = {
         "golfbox": {
             "resource_guid": "1BEE50FC-669C-4383-A47E-5354F7AC08EC",
             "club_guid": "EE00C492-7F02-4C2C-851B-8CDDC89181DB",
+            "mcp_slug": "grini_gk",
         },
     },
     "losby": {
@@ -106,6 +109,7 @@ facilities = {
         "golfbox": {
             "resource_guid": "3C44C599-4A4C-40D9-8AF7-9F3CDB9EDD7F",
             "club_guid": "90FA30D3-FF9D-4C3E-92C9-115B01A8D7BD",
+            "mcp_slug": "losby_golfklubb",
         },
     },
     "rivertz": {

--- a/lambdas/golf-scraper/handler.py
+++ b/lambdas/golf-scraper/handler.py
@@ -36,6 +36,14 @@ AWS_REGION = os.environ.get("AWS_REGION", "eu-north-1")
 # fall back to the legacy path.
 GOLF_DATA_SOURCE = os.environ.get("GOLF_DATA_SOURCE", "mcp").lower()
 
+# Circuit breaker for the MCP path. A broken OAuth chain fails identically for
+# every facility+date, so without this the handler would retry all
+# (facilities × DAYS_AHEAD) combinations — each a refresh attempt — and hammer
+# Vardenlab's token endpoint into rate-limiting (429). Once this many auth
+# failures accumulate, abort the whole run; one bad token = a handful of log
+# lines, not dozens. See the 2026-05-21 incident in TROUBLESHOOTING.md.
+MCP_AUTH_FAILURE_LIMIT = int(os.environ.get("MCP_AUTH_FAILURE_LIMIT", "3"))
+
 # Lazy-loaded AWS clients
 _dynamodb = None
 _lambda_client = None
@@ -238,8 +246,12 @@ def lambda_handler(event, context):
     total_slots = 0
     fetch_errors = 0
     auth_failures = 0
+    mcp_auth_aborted = False
 
     for facility_key, config in golf_facilities.items():
+        if mcp_auth_aborted:
+            break
+
         golfbox_config = get_golfbox_config(facility_key)
         if not golfbox_config:
             continue
@@ -262,6 +274,13 @@ def lambda_handler(event, context):
                     auth_failures += 1
                     fetch_errors += 1
                     logger.error("MCP auth failure: %s", e)
+                    if auth_failures >= MCP_AUTH_FAILURE_LIMIT:
+                        logger.error(
+                            "MCP auth failed %d times — aborting run to avoid "
+                            "hammering the token endpoint", auth_failures,
+                        )
+                        mcp_auth_aborted = True
+                        break
                     continue
                 except Exception as e:
                     fetch_errors += 1
@@ -294,9 +313,9 @@ def lambda_handler(event, context):
     elapsed = time.monotonic() - start_time
     logger.info(
         "Golf scraper complete: source=%s, slots=%d, errors=%d, auth_failures=%d, "
-        "diff_keys=%d, elapsed=%.1fs",
+        "auth_aborted=%s, diff_keys=%d, elapsed=%.1fs",
         GOLF_DATA_SOURCE, total_slots, fetch_errors, auth_failures,
-        len(full_diff), elapsed,
+        mcp_auth_aborted, len(full_diff), elapsed,
     )
 
     return {
@@ -306,6 +325,7 @@ def lambda_handler(event, context):
             "totalSlots": total_slots,
             "fetchErrors": fetch_errors,
             "authFailures": auth_failures,
+            "authAborted": mcp_auth_aborted,
             "diffFacilities": len(full_diff),
             "elapsed": round(elapsed, 1),
         }),

--- a/lambdas/golf-scraper/handler.py
+++ b/lambdas/golf-scraper/handler.py
@@ -44,6 +44,16 @@ GOLF_DATA_SOURCE = os.environ.get("GOLF_DATA_SOURCE", "mcp").lower()
 # lines, not dozens. See the 2026-05-21 incident in TROUBLESHOOTING.md.
 MCP_AUTH_FAILURE_LIMIT = int(os.environ.get("MCP_AUTH_FAILURE_LIMIT", "3"))
 
+# Single-runner lock for the MCP path. Two concurrent invocations sharing the
+# rotating Vardenlab refresh token revoke each other's token family (see the
+# 2026-05-21 incident in TROUBLESHOOTING.md). Reserved concurrency=1 would be
+# the natural guard, but this account's Lambda concurrency limit is 10 and AWS
+# forbids dropping unreserved below 10, so we serialize with a DynamoDB
+# conditional-write lock instead. The TTL lets a crashed run's lock self-expire
+# (kept comfortably above the ~100s runtime, below the 20-min schedule).
+RUN_LOCK_KEY = "mcp-run-lock"
+RUN_LOCK_TTL = int(os.environ.get("MCP_RUN_LOCK_TTL", "300"))
+
 # Lazy-loaded AWS clients
 _dynamodb = None
 _lambda_client = None
@@ -92,6 +102,38 @@ def _cache_session(cookies):
         "cookies": json.dumps(cookies),
         "expiresAt": expires_at,
     })
+
+
+def _acquire_run_lock(ttl_seconds=RUN_LOCK_TTL):
+    """Acquire the MCP single-runner lock. Returns True if acquired.
+
+    Conditional write on the golf-sessions table: succeeds only when no lock
+    exists or the existing one has logically expired. Prevents two concurrent
+    invocations from racing on the rotating refresh token.
+    """
+    table = _get_dynamodb().Table(SESSION_TABLE)
+    now = int(time.time())
+    try:
+        table.put_item(
+            Item={"sessionId": RUN_LOCK_KEY, "expiresAt": now + ttl_seconds, "acquiredAt": now},
+            ConditionExpression="attribute_not_exists(sessionId) OR expiresAt < :now",
+            ExpressionAttributeValues={":now": now},
+        )
+        return True
+    except ClientError as e:
+        if e.response.get("Error", {}).get("Code") == "ConditionalCheckFailedException":
+            return False
+        raise
+
+
+def _release_run_lock():
+    """Release the MCP single-runner lock. Best-effort — a missed release just
+    falls back to TTL expiry."""
+    table = _get_dynamodb().Table(SESSION_TABLE)
+    try:
+        table.delete_item(Key={"sessionId": RUN_LOCK_KEY})
+    except ClientError as e:
+        logger.warning("Failed to release MCP run lock: %s", e)
 
 
 def _load_previous_snapshot(table, composite_key, date_strings):
@@ -210,13 +252,35 @@ def _fetch_slots_via_mcp(golfbox_config, date_str):
 
 def lambda_handler(event, context):
     """AWS Lambda entry point."""
-    from facilities import get_facilities_for_sport, get_golfbox_config
-
     start_time = time.monotonic()
     logger.info(
         "Golf scraper invoked, days_ahead=%d, source=%s",
         DAYS_AHEAD, GOLF_DATA_SOURCE,
     )
+
+    # MCP path must run one-at-a-time (rotating-refresh-token race). The scrape
+    # path is idempotent and concurrency-safe, so it skips the lock.
+    mcp_mode = GOLF_DATA_SOURCE == "mcp"
+    if mcp_mode and not _acquire_run_lock():
+        logger.warning(
+            "Another golf-scraper MCP run holds the lock; skipping this "
+            "invocation to avoid a refresh-token race",
+        )
+        return {
+            "statusCode": 200,
+            "body": json.dumps({"source": GOLF_DATA_SOURCE, "skipped": "locked"}),
+        }
+
+    try:
+        return _run_scrape(start_time)
+    finally:
+        if mcp_mode:
+            _release_run_lock()
+
+
+def _run_scrape(start_time):
+    """Core scrape/MCP run. Wrapped by lambda_handler's run-lock."""
+    from facilities import get_facilities_for_sport, get_golfbox_config
 
     # Legacy scrape path also needs login + session caching. MCP path is
     # stateless from the handler's perspective; mcp_client manages its

--- a/lambdas/golf-scraper/handler.py
+++ b/lambdas/golf-scraper/handler.py
@@ -27,6 +27,15 @@ NOTIFICATIONS_FUNCTION = os.environ.get("NOTIFICATIONS_FUNCTION", "")
 DAYS_AHEAD = int(os.environ.get("SCRAPER_DAYS_AHEAD", "14"))
 AWS_REGION = os.environ.get("AWS_REGION", "eu-north-1")
 
+# Data-source switch. "mcp" = call Vardenlab's GolfBox MCP, which proxies
+# through a Norwegian IP and returns the member view (correct price tier,
+# real tournament blocks). "scrape" = legacy direct-GolfBox HTTP path, which
+# from AWS IPs gets the guest view (wrong price tier, false tournament
+# negatives). Defaults to mcp; requires the OAuth secret to be provisioned
+# first (scripts/golfbox_mcp_oauth_setup.py). Set GOLF_DATA_SOURCE=scrape to
+# fall back to the legacy path.
+GOLF_DATA_SOURCE = os.environ.get("GOLF_DATA_SOURCE", "mcp").lower()
+
 # Lazy-loaded AWS clients
 _dynamodb = None
 _lambda_client = None
@@ -158,29 +167,66 @@ def _invoke_notifications(diff):
     logger.info("Invoked notifications Lambda with %d facility keys", len(diff))
 
 
+def _fetch_slots_via_scrape(client, golfbox_config, date_str, _cache_session_cb):
+    """Legacy path: log into GolfBox, fetch HTML grid, parse."""
+    from parser import parse_grid_html
+
+    resource_guid = golfbox_config["resource_guid"]
+    club_guid = golfbox_config["club_guid"]
+
+    html = client.fetch_grid(resource_guid, club_guid, date_str)
+    if html is None and not client._logged_in:
+        logger.info("Re-logging in after session expiry")
+        if not client.login():
+            return None
+        _cache_session_cb(client.cookies_dict)
+        html = client.fetch_grid(resource_guid, club_guid, date_str)
+    if html is None:
+        return None
+    return parse_grid_html(html)
+
+
+def _fetch_slots_via_mcp(golfbox_config, date_str):
+    """MCP path: call Vardenlab MCP, map to parser-format dict."""
+    import mcp_client
+    from mcp_to_slots import mcp_slots_to_dict
+
+    mcp_slug = golfbox_config.get("mcp_slug")
+    if not mcp_slug:
+        logger.warning("Facility missing mcp_slug; skipping")
+        return None
+
+    mcp_slots = mcp_client.search_tee_times(mcp_slug, date_str, only_free=True)
+    return mcp_slots_to_dict(mcp_slots)
+
+
 def lambda_handler(event, context):
     """AWS Lambda entry point."""
-    from scraper import GolfBoxClient
-    from parser import parse_grid_html
     from facilities import get_facilities_for_sport, get_golfbox_config
 
     start_time = time.monotonic()
-    logger.info("Golf scraper invoked, days_ahead=%d", DAYS_AHEAD)
+    logger.info(
+        "Golf scraper invoked, days_ahead=%d, source=%s",
+        DAYS_AHEAD, GOLF_DATA_SOURCE,
+    )
 
-    # Initialize client
-    client = GolfBoxClient(GOLFBOX_USERNAME, GOLFBOX_PASSWORD)
+    # Legacy scrape path also needs login + session caching. MCP path is
+    # stateless from the handler's perspective; mcp_client manages its
+    # own token cache internally.
+    scrape_client = None
+    if GOLF_DATA_SOURCE == "scrape":
+        from scraper import GolfBoxClient
 
-    # Try cached session first
-    cached_cookies = _get_cached_session()
-    if cached_cookies:
-        client.restore_cookies(cached_cookies)
-        logger.info("Restored cached GolfBox session")
-    else:
-        if not client.login():
-            return {"statusCode": 500, "body": "GolfBox login failed"}
-        _cache_session(client.cookies_dict)
+        scrape_client = GolfBoxClient(GOLFBOX_USERNAME, GOLFBOX_PASSWORD)
+        cached_cookies = _get_cached_session()
+        if cached_cookies:
+            scrape_client.restore_cookies(cached_cookies)
+            logger.info("Restored cached GolfBox session")
+        else:
+            if not scrape_client.login():
+                return {"statusCode": 500, "body": "GolfBox login failed"}
+            _cache_session(scrape_client.cookies_dict)
 
-    # Prepare dates
     today = datetime.date.today()
     dates = [today + datetime.timedelta(days=i) for i in range(DAYS_AHEAD)]
     date_strings = [d.strftime("%Y-%m-%d") for d in dates]
@@ -191,6 +237,7 @@ def lambda_handler(event, context):
     full_diff = {}
     total_slots = 0
     fetch_errors = 0
+    auth_failures = 0
 
     for facility_key, config in golf_facilities.items():
         golfbox_config = get_golfbox_config(facility_key)
@@ -198,62 +245,67 @@ def lambda_handler(event, context):
             continue
 
         composite_key = f"{facility_key}#golf"
-        resource_guid = golfbox_config["resource_guid"]
-        club_guid = golfbox_config["club_guid"]
-
-        # Load previous snapshot
-        previous = _load_previous_snapshot(availability_table, composite_key, date_strings)
-
+        previous = _load_previous_snapshot(
+            availability_table, composite_key, date_strings,
+        )
         facility_diff = {}
 
         for date_str in date_strings:
-            html = client.fetch_grid(resource_guid, club_guid, date_str)
+            current_slots = None
 
-            # If session expired mid-scrape, re-login and retry
-            if html is None and not client._logged_in:
-                logger.info("Re-logging in after session expiry")
-                if not client.login():
+            if GOLF_DATA_SOURCE == "mcp":
+                import mcp_client
+
+                try:
+                    current_slots = _fetch_slots_via_mcp(golfbox_config, date_str)
+                except mcp_client.MCPAuthError as e:
+                    auth_failures += 1
+                    fetch_errors += 1
+                    logger.error("MCP auth failure: %s", e)
+                    continue
+                except Exception as e:
+                    fetch_errors += 1
+                    logger.warning(
+                        "MCP fetch error for %s/%s: %s", facility_key, date_str, e,
+                    )
+                    continue
+            else:
+                current_slots = _fetch_slots_via_scrape(
+                    scrape_client, golfbox_config, date_str, _cache_session,
+                )
+                if current_slots is None:
                     fetch_errors += 1
                     continue
-                _cache_session(client.cookies_dict)
-                html = client.fetch_grid(resource_guid, club_guid, date_str)
 
-            if html is None:
-                fetch_errors += 1
-                continue
-
-            current_slots = parse_grid_html(html)
             total_slots += len(current_slots)
-
-            # Save current snapshot
             _save_snapshot(availability_table, composite_key, date_str, current_slots)
 
-            # Diff against previous — spot-aware: only emit when spot
-            # count increased for a given tee (see _compute_new_slots).
             prev_slots = previous.get(date_str, {})
             new_slots = _compute_new_slots(prev_slots, current_slots)
-
             if new_slots:
                 facility_diff[date_str] = new_slots
 
         if facility_diff:
             full_diff[composite_key] = facility_diff
 
-    # Invoke notifications if we have new availability
     if full_diff:
         _invoke_notifications(full_diff)
 
     elapsed = time.monotonic() - start_time
     logger.info(
-        "Golf scraper complete: slots=%d, errors=%d, diff_keys=%d, elapsed=%.1fs",
-        total_slots, fetch_errors, len(full_diff), elapsed,
+        "Golf scraper complete: source=%s, slots=%d, errors=%d, auth_failures=%d, "
+        "diff_keys=%d, elapsed=%.1fs",
+        GOLF_DATA_SOURCE, total_slots, fetch_errors, auth_failures,
+        len(full_diff), elapsed,
     )
 
     return {
         "statusCode": 200,
         "body": json.dumps({
+            "source": GOLF_DATA_SOURCE,
             "totalSlots": total_slots,
             "fetchErrors": fetch_errors,
+            "authFailures": auth_failures,
             "diffFacilities": len(full_diff),
             "elapsed": round(elapsed, 1),
         }),

--- a/lambdas/golf-scraper/mcp_client.py
+++ b/lambdas/golf-scraper/mcp_client.py
@@ -1,0 +1,270 @@
+"""Vardenlab MCP HTTP client for Lambda — token refresh + tools/call.
+
+Architecture:
+- Long-lived state (client_id, client_secret, refresh_token) lives in AWS
+  Secrets Manager under the secret name in MCP_TOKEN_SECRET env var. The
+  initial OAuth handshake (PKCE auth-code flow) is a one-time interactive
+  step done from a workstation — see scripts/golfbox_mcp_oauth_setup.py.
+- Short-lived state (access_token, mcp_session_id) lives in this module's
+  module-level cache, so it survives across invocations within a single
+  warm Lambda container but is rebuilt on cold start (or 401 retry).
+- A 401 on a tool call triggers exactly one refresh + retry. If refresh
+  fails too, we surface MCPAuthError so the handler can fall back to the
+  legacy scrape path (GOLF_DATA_SOURCE fallback semantics).
+
+This module ONLY talks HTTP to https://mcp.vardenlab.com — it does not
+import boto3 at the top level so unit tests can stub the secret loader.
+"""
+
+import json
+import logging
+import os
+import time
+import urllib.parse
+import urllib.request
+
+logger = logging.getLogger(__name__)
+
+MCP_BASE_URL = "https://mcp.vardenlab.com"
+MCP_TOOL_URL = f"{MCP_BASE_URL}/api/mcp/golfbox"
+TOKEN_URL = f"{MCP_BASE_URL}/api/oauth/token"
+MCP_PROTOCOL_VERSION = "2025-03-26"
+
+# Module-level caches for warm-container reuse. Reset on cold start.
+_access_token = None
+_access_expires_at = 0
+_session_id = None
+_initialized = False
+_creds_cache = None
+
+
+class MCPAuthError(Exception):
+    """Raised when OAuth refresh fails — caller should fall back to scrape."""
+
+
+class MCPError(Exception):
+    """Raised for non-auth MCP failures (transport, invalid response)."""
+
+
+def _load_credentials():
+    """Load client_id, client_secret (optional), refresh_token from Secrets Manager.
+
+    The secret JSON shape (as written by scripts/golfbox_mcp_oauth_setup.py):
+        {
+          "client_id": "mcp_...",
+          "client_secret": "..."  // optional, only for confidential clients
+          "refresh_token": "rt_..."
+        }
+    """
+    global _creds_cache
+    if _creds_cache is not None:
+        return _creds_cache
+
+    import boto3  # imported lazily so tests/local PoC don't require it
+
+    secret_name = os.environ.get("MCP_TOKEN_SECRET", "golfbox-mcp-tokens")
+    region = os.environ.get("AWS_REGION", "eu-north-1")
+    client = boto3.client("secretsmanager", region_name=region)
+    resp = client.get_secret_value(SecretId=secret_name)
+    creds = json.loads(resp["SecretString"])
+
+    if not creds.get("client_id") or not creds.get("refresh_token"):
+        raise MCPAuthError(
+            f"Secret {secret_name} missing client_id or refresh_token — "
+            "run scripts/golfbox_mcp_oauth_setup.py first"
+        )
+    _creds_cache = creds
+    return creds
+
+
+def _persist_refresh_token(new_refresh_token):
+    """Write a rotated refresh_token back to Secrets Manager.
+
+    Vardenlab may issue a new refresh_token on each /token call (refresh
+    rotation). We persist only when it actually changes to keep
+    Secrets-Manager write volume low.
+    """
+    global _creds_cache
+    if not _creds_cache or _creds_cache.get("refresh_token") == new_refresh_token:
+        return
+    import boto3
+    secret_name = os.environ.get("MCP_TOKEN_SECRET", "golfbox-mcp-tokens")
+    region = os.environ.get("AWS_REGION", "eu-north-1")
+    client = boto3.client("secretsmanager", region_name=region)
+    _creds_cache["refresh_token"] = new_refresh_token
+    client.update_secret(
+        SecretId=secret_name,
+        SecretString=json.dumps(_creds_cache),
+    )
+    logger.info("Rotated MCP refresh_token persisted")
+
+
+def _refresh_access_token():
+    """Trade refresh_token for a fresh access_token."""
+    global _access_token, _access_expires_at, _session_id, _initialized
+    creds = _load_credentials()
+
+    form = {
+        "grant_type": "refresh_token",
+        "refresh_token": creds["refresh_token"],
+        "client_id": creds["client_id"],
+        # RFC 8707 resource indicator — Vardenlab's token endpoint requires it
+        # ("invalid_target" otherwise), including on refresh_token grants.
+        "resource": MCP_TOOL_URL,
+    }
+    if creds.get("client_secret"):
+        form["client_secret"] = creds["client_secret"]
+
+    body = urllib.parse.urlencode(form).encode()
+    req = urllib.request.Request(TOKEN_URL, data=body, method="POST")
+    req.add_header("Content-Type", "application/x-www-form-urlencoded")
+    req.add_header("Accept", "application/json")
+    try:
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            data = json.loads(resp.read())
+    except urllib.error.HTTPError as e:
+        raise MCPAuthError(f"Token refresh HTTP {e.code}: {e.read()[:200]}") from e
+    except urllib.error.URLError as e:
+        raise MCPAuthError(f"Token refresh URL error: {e.reason}") from e
+
+    if "access_token" not in data:
+        raise MCPAuthError(f"Token refresh returned no access_token: {data}")
+
+    _access_token = data["access_token"]
+    expires_in = int(data.get("expires_in", 3600))
+    _access_expires_at = int(time.time()) + expires_in - 60  # 60s safety margin
+    # Refresh invalidates any prior MCP session — force re-initialize
+    _session_id = None
+    _initialized = False
+
+    if data.get("refresh_token") and data["refresh_token"] != creds["refresh_token"]:
+        _persist_refresh_token(data["refresh_token"])
+
+    logger.info("MCP access token refreshed, expires_in=%d", expires_in)
+
+
+def _ensure_access_token():
+    if _access_token and time.time() < _access_expires_at:
+        return _access_token
+    _refresh_access_token()
+    return _access_token
+
+
+def _post_jsonrpc(payload, expect_response=True):
+    """Send a JSON-RPC envelope to the MCP endpoint. Returns parsed response.
+
+    Handles both application/json and text/event-stream responses since
+    Vercel-hosted MCP servers may emit either format.
+    """
+    global _session_id
+    access = _ensure_access_token()
+    body = json.dumps(payload).encode()
+    req = urllib.request.Request(MCP_TOOL_URL, data=body, method="POST")
+    req.add_header("Content-Type", "application/json")
+    req.add_header("Accept", "application/json, text/event-stream")
+    req.add_header("Authorization", f"Bearer {access}")
+    if _session_id:
+        req.add_header("Mcp-Session-Id", _session_id)
+
+    try:
+        resp = urllib.request.urlopen(req, timeout=30)
+    except urllib.error.HTTPError as e:
+        if e.code == 401:
+            raise MCPAuthError(f"MCP returned 401: {e.read()[:200]}") from e
+        raise MCPError(f"MCP HTTP {e.code}: {e.read()[:200]}") from e
+    except urllib.error.URLError as e:
+        raise MCPError(f"MCP URL error: {e.reason}") from e
+
+    new_session = resp.headers.get("Mcp-Session-Id")
+    if new_session:
+        _session_id = new_session
+
+    raw = resp.read()
+    if not expect_response:
+        return None
+
+    ctype = resp.headers.get("Content-Type", "")
+    if "event-stream" in ctype:
+        text = raw.decode()
+        for line in text.split("\n"):
+            if line.startswith("data:"):
+                return json.loads(line[5:].strip())
+        raise MCPError(f"SSE response with no data: {text[:200]}")
+    return json.loads(raw)
+
+
+def _initialize_session():
+    """MCP streamable-HTTP handshake: initialize → notifications/initialized."""
+    global _initialized
+    resp = _post_jsonrpc({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": MCP_PROTOCOL_VERSION,
+            "capabilities": {},
+            "clientInfo": {"name": "tennis-bot-golf-scraper", "version": "1.0.0"},
+        },
+    })
+    if "error" in resp:
+        raise MCPError(f"initialize failed: {resp['error']}")
+    _post_jsonrpc(
+        {"jsonrpc": "2.0", "method": "notifications/initialized"},
+        expect_response=False,
+    )
+    _initialized = True
+    logger.info("MCP session initialized, session_id=%s", _session_id)
+
+
+def _call_tool(name, arguments, request_id):
+    if not _initialized:
+        _initialize_session()
+    resp = _post_jsonrpc({
+        "jsonrpc": "2.0",
+        "id": request_id,
+        "method": "tools/call",
+        "params": {"name": name, "arguments": arguments},
+    })
+    if "error" in resp:
+        raise MCPError(f"tool {name} failed: {resp['error']}")
+    content = resp.get("result", {}).get("content", [])
+    if not content:
+        return []
+    # MCP tool responses wrap structured data as JSON text in content[0].text
+    text_payload = content[0].get("text", "")
+    try:
+        return json.loads(text_payload)
+    except json.JSONDecodeError:
+        return text_payload
+
+
+def search_tee_times(club, date, only_free=True):
+    """Call MCP search_tee_times. Returns list of slot dicts.
+
+    Raises MCPAuthError if OAuth flow is broken (caller should fall back to
+    scrape path); MCPError for transport/parsing failures.
+    """
+    args = {"club": club, "date": date, "only_free": only_free}
+
+    # Single retry on 401 — token may have just expired between cache check
+    # and request, or session_id may have been invalidated server-side.
+    try:
+        return _call_tool("search_tee_times", args, request_id=int(time.time()))
+    except MCPAuthError:
+        global _initialized, _session_id, _access_token, _access_expires_at
+        _initialized = False
+        _session_id = None
+        _access_token = None
+        _access_expires_at = 0
+        _refresh_access_token()
+        return _call_tool("search_tee_times", args, request_id=int(time.time()))
+
+
+def reset_for_tests():
+    """Test helper: wipe all module-level cache."""
+    global _access_token, _access_expires_at, _session_id, _initialized, _creds_cache
+    _access_token = None
+    _access_expires_at = 0
+    _session_id = None
+    _initialized = False
+    _creds_cache = None

--- a/lambdas/golf-scraper/mcp_to_slots.py
+++ b/lambdas/golf-scraper/mcp_to_slots.py
@@ -1,0 +1,148 @@
+"""Map Vardenlab MCP search_tee_times response → parser-format dict.
+
+The rest of the pipeline (handler._compute_new_slots, downstream notifications,
+newsletter) expects slot data as:
+    {"HH:MM": ["N spot[s] (price,-)", ...], ...}
+
+The MCP returns a list of slot dicts with:
+    start: ISO timestamp
+    status: free|partial|full|expired|too_far_ahead|tournament|closed|blocked|unknown
+    capacity: int or null
+    booked: int or null
+    raw_label: messy concatenation that contains the price near the end
+
+This module converts the MCP shape to the dict format, filtering to only
+actionable slots (free + partial with >=1 free spot) and skipping every
+blocked variant (tournament, closed, blocked, expired, too_far_ahead, full).
+"""
+
+import logging
+import re
+
+logger = logging.getLogger(__name__)
+
+TEE_CAPACITY = 4
+ACTIONABLE_STATUSES = {"free", "partial"}
+# Price extraction is messy because MCP concatenates time ("07:00"),
+# handicap decimals ("hcp:21,7"), and the price into one unseparated
+# tail. See _extract_price for the case logic.
+HANDICAP_MERGED_PRICE = re.compile(r",\d(\d{3,4})$")
+TRAILING_DIGITS = re.compile(r"(\d+)$")
+
+
+def _extract_time_key(start_iso):
+    """'2026-05-25T07:09:00' -> '07:09'. Returns None if unparseable."""
+    if not start_iso or "T" not in start_iso:
+        return None
+    try:
+        hhmm = start_iso.split("T", 1)[1][:5]
+    except (IndexError, AttributeError):
+        return None
+    if len(hhmm) != 5 or hhmm[2] != ":":
+        return None
+    return hhmm
+
+
+def _extract_price(raw_label):
+    """Extract the price from the END of raw_label as 'NNN,-' string.
+
+    Cases (after stripping the optional ',-' suffix):
+      A. Trailing run is preceded by 'NN,N' (handicap decimal) — capture
+         the 3-4 digits after that single handicap digit as the price.
+      B. Trailing digit run length tells us how to split:
+           3 → bare 3-digit price ("845")
+           4 → bare 4-digit price ("1095") if leading digit is 1-9
+           5 → HH:MM(NN) merged with 3-digit price → take last 3
+           6 → HH:MM(NN) merged with 4-digit price → take last 4
+              (only if that last-4 starts 1-9; else give up)
+    Returns None on any other shape (truncated labels, garbage).
+    """
+    if not raw_label:
+        return None
+    s = raw_label.rstrip()
+    if s.endswith(",-"):
+        s = s[:-2].rstrip(",")
+
+    match = HANDICAP_MERGED_PRICE.search(s)
+    if match:
+        return f"{match.group(1)},-"
+
+    match = TRAILING_DIGITS.search(s)
+    if not match:
+        return None
+    digits = match.group(1)
+    n = len(digits)
+
+    if n == 3:
+        return f"{digits},-"
+    if n == 4 and digits[0] != "0":
+        return f"{digits},-"
+    if n == 5:
+        return f"{digits[-3:]},-"
+    if n == 6:
+        last4 = digits[-4:]
+        if last4[0] != "0":
+            return f"{last4},-"
+    return None
+
+
+def _spots_available(slot):
+    """How many seats are still bookable on this tee."""
+    status = slot.get("status")
+    if status == "free":
+        return TEE_CAPACITY
+    if status != "partial":
+        return 0
+    capacity = slot.get("capacity") or TEE_CAPACITY
+    booked = slot.get("booked")
+    if booked is None:
+        # MCP reports partial but didn't fill booked — fall back to
+        # counting parsed player entries. We deliberately do NOT trust the
+        # raw_label name count here (the MCP truncates raw_label at ~120 chars).
+        booked = len(slot.get("players") or []) or 1
+    return max(0, capacity - booked)
+
+
+def mcp_slots_to_dict(mcp_slots):
+    """Convert MCP slot list to {time_key: [description, ...]}.
+
+    Drops slots whose status is anything other than free/partial, and drops
+    partial slots with 0 spots left (i.e. genuinely full despite the
+    "partial" label — rare but possible).
+    """
+    result = {}
+    skipped_status = 0
+
+    for slot in mcp_slots:
+        status = slot.get("status")
+        if status not in ACTIONABLE_STATUSES:
+            skipped_status += 1
+            continue
+
+        time_key = _extract_time_key(slot.get("start"))
+        if not time_key:
+            continue
+
+        spots = _spots_available(slot)
+        if spots <= 0:
+            continue
+
+        # NOTE(price-truncation): crowded "partial" tees concatenate every
+        # player name into raw_label, which the MCP caps at ~120 chars — the
+        # trailing price often gets cut off, so those slots render as
+        # "N spots" with no price. Spot count is still correct (from
+        # capacity/booked), so matching is unaffected; only the cosmetic price
+        # is missing. Verified against live data 2026-05-21 (Onsøy).
+        price = _extract_price(slot.get("raw_label"))
+        spot_word = "spot" if spots == 1 else "spots"
+        description = (
+            f"{spots} {spot_word} ({price})" if price else f"{spots} {spot_word}"
+        )
+        result.setdefault(time_key, []).append(description)
+
+    if skipped_status:
+        logger.debug(
+            "mcp_slots_to_dict: skipped %d non-actionable slots, kept %d times",
+            skipped_status, len(result),
+        )
+    return result

--- a/lambdas/golf-scraper/requirements.txt
+++ b/lambdas/golf-scraper/requirements.txt
@@ -1,3 +1,4 @@
 requests>=2.31.0
 beautifulsoup4>=4.12.0
 boto3>=1.28.0
+curl_cffi>=0.7.0

--- a/lambdas/golf-scraper/scraper.py
+++ b/lambdas/golf-scraper/scraper.py
@@ -1,11 +1,27 @@
-"""GolfBox HTTP client — login, session management, grid fetching."""
+"""GolfBox HTTP client — login, session management, grid fetching.
+
+LIMITATION: When run from AWS Lambda (eu-north-1 / Stockholm exit IP),
+GolfBox's load balancer routes us into the guest IIS app-pool, which
+returns a stripped grid with wrong price tier (795,- guest rate vs 845,-
+member rate) and tournament-blocked cells re-exposed as bookable.
+
+The same code run from a Norwegian residential IP returns the member view
+correctly. TLS impersonation via curl_cffi was tried as a workaround — it
+did not change behavior, but we keep it because it doesn't hurt and may
+help if GolfBox starts UA/TLS-gating in the future.
+
+The Lambda pipeline pivots to the Vardenlab MCP path (see mcp_client.py)
+when GOLF_DATA_SOURCE=mcp, which sidesteps the IP-routing issue entirely.
+"""
 
 import logging
-import requests
+from curl_cffi import requests
+from curl_cffi.requests.exceptions import RequestException
 
 logger = logging.getLogger(__name__)
 
 GOLFBOX_LOGIN_URL = "https://www.golfbox.no/login.asp"
+GOLFBOX_FRONTPAGE_URL = "https://www.golfbox.no/site/my_golfbox/myFrontPage.asp"
 GOLFBOX_GRID_BASE = (
     "https://www.golfbox.no/site/my_golfbox/ressources/booking/grid.asp"
 )
@@ -37,16 +53,49 @@ class GolfBoxClient:
     def __init__(self, username, password):
         self._username = username
         self._password = password
-        self._session = requests.Session()
+        # impersonate=chrome131 — match latest stable Chrome TLS+H2 fingerprint.
+        # Without this, GolfBox serves the guest view (see module docstring).
+        self._session = requests.Session(impersonate="chrome131")
+        # GolfBox returns a stripped guest view to clients with the default
+        # python-requests User-Agent (wrong price tier, tournament blocks shown
+        # as bookable). Identify as a real browser.
+        self._session.headers.update({
+            "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36",
+            "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8",
+            "Accept-Language": "nb-NO,nb;q=0.9,en;q=0.8",
+            "Accept-Encoding": "gzip, deflate, br, zstd",
+            "Upgrade-Insecure-Requests": "1",
+            "Sec-Fetch-Dest": "document",
+            "Sec-Fetch-Mode": "navigate",
+            "Sec-Fetch-Site": "same-origin",
+            "Sec-Fetch-User": "?1",
+            "sec-ch-ua": '"Chromium";v="131", "Not_A Brand";v="24", "Google Chrome";v="131"',
+            "sec-ch-ua-mobile": "?0",
+            "sec-ch-ua-platform": '"macOS"',
+        })
         self._logged_in = False
 
     def login(self):
-        """Authenticate with GolfBox. Returns True on success."""
-        # Clear any cookies from a previous (possibly stale) session — keeping
-        # them around causes duplicate cookies (e.g. two ``logoutPage`` entries
-        # on different paths) that make ``dict(session.cookies)`` blow up with
-        # CookieConflictError when we try to cache the new session.
+        """Authenticate with GolfBox. Returns True on success.
+
+        Browser-like flow:
+        1. GET /login.asp to collect initial session cookies + Set-Cookie state
+        2. POST credentials with allow_redirects=True so we follow the full
+           302 chain and collect every Set-Cookie along the way (the booking
+           grid requires the /site/my_golfbox/ path cookie that's only set
+           on a later hop)
+        3. GET /site/my_golfbox/myFrontPage.asp as a final warm-up to ensure
+           the member-view session is fully primed (without this the grid
+           sometimes returns the anonymous/guest view: wrong price tier and
+           tournament blocks treated as bookable)
+        """
         self._session.cookies.clear()
+        self._session.cookies.set("cookiePolicy", "accepted", domain="www.golfbox.no", path="/")
+
+        try:
+            self._session.get(GOLFBOX_LOGIN_URL, timeout=10)
+        except RequestException as e:
+            logger.warning("Pre-login GET failed: %s", e)
 
         resp = self._session.post(
             GOLFBOX_LOGIN_URL,
@@ -57,18 +106,35 @@ class GolfBoxClient:
                 "command": "login",
                 "redirect": "//www.norskgolf.no",
             },
-            allow_redirects=False,
-            timeout=10,
+            headers={
+                "Origin": "https://www.golfbox.no",
+                "Referer": "https://www.golfbox.no/login.asp",
+                "Content-Type": "application/x-www-form-urlencoded",
+                "Sec-Fetch-Site": "same-origin",
+            },
+            allow_redirects=True,
+            timeout=15,
         )
 
-        if resp.status_code == 302:
-            self._logged_in = True
-            logger.info("GolfBox login successful")
-            return True
+        if resp.status_code >= 400:
+            logger.error("GolfBox login failed: status=%d url=%s", resp.status_code, resp.url)
+            self._logged_in = False
+            return False
 
-        logger.error("GolfBox login failed: status=%d", resp.status_code)
-        self._logged_in = False
-        return False
+        if "login.asp" in resp.url.lower():
+            logger.error("GolfBox login bounced back to login.asp — bad credentials?")
+            self._logged_in = False
+            return False
+
+        try:
+            self._session.get(GOLFBOX_FRONTPAGE_URL, timeout=10)
+        except RequestException as e:
+            logger.warning("Frontpage warm-up failed: %s", e)
+
+        self._logged_in = True
+        logger.info("GolfBox login successful, cookies=%d, final_url=%s",
+                    len(self._session.cookies), resp.url)
+        return True
 
     def fetch_grid(self, resource_guid, club_guid, date_str):
         """Fetch a grid page HTML. Returns None on failure."""
@@ -79,7 +145,7 @@ class GolfBoxClient:
         url = build_grid_url(resource_guid, club_guid, date_str)
         try:
             resp = self._session.get(url, timeout=15)
-        except requests.RequestException as e:
+        except RequestException as e:
             logger.error("Grid fetch failed for %s: %s", date_str, e)
             return None
 

--- a/lambdas/golf-scraper/scraper.py
+++ b/lambdas/golf-scraper/scraper.py
@@ -42,6 +42,12 @@ class GolfBoxClient:
 
     def login(self):
         """Authenticate with GolfBox. Returns True on success."""
+        # Clear any cookies from a previous (possibly stale) session — keeping
+        # them around causes duplicate cookies (e.g. two ``logoutPage`` entries
+        # on different paths) that make ``dict(session.cookies)`` blow up with
+        # CookieConflictError when we try to cache the new session.
+        self._session.cookies.clear()
+
         resp = self._session.post(
             GOLFBOX_LOGIN_URL,
             data={

--- a/lambdas/golf-scraper/scraper.py
+++ b/lambdas/golf-scraper/scraper.py
@@ -81,9 +81,12 @@ class GolfBoxClient:
             logger.error("Grid fetch non-200: status=%d url=%s", resp.status_code, url)
             return None
 
-        # Detect redirect to login page (session expired)
-        if "login.asp" in resp.url or len(resp.text) < 1000:
-            logger.warning("Session expired, grid fetch redirected to login")
+        # Detect logged-out response. GolfBox does not always redirect to
+        # login.asp for a stale session — sometimes it returns a 200 with a
+        # generic page that lacks the booking grid. The parser keys off the
+        # bookingGridv3 div, so use its absence as the session-expiry signal.
+        if "login.asp" in resp.url or "bookingGridv3" not in resp.text:
+            logger.warning("Session expired or grid missing for %s", date_str)
             self._logged_in = False
             return None
 

--- a/scripts/golfbox_mcp_oauth_setup.py
+++ b/scripts/golfbox_mcp_oauth_setup.py
@@ -1,0 +1,231 @@
+"""One-time interactive OAuth setup for the golf-scraper Lambda's MCP path.
+
+Run this ONCE from a workstation (anywhere with a browser). It:
+1. Dynamically registers an OAuth client with Vardenlab MCP
+2. Walks the PKCE auth-code flow (opens browser, captures callback on 127.0.0.1)
+3. Trades the code for access + refresh tokens
+4. Writes {client_id, client_secret?, refresh_token} to AWS Secrets Manager
+   under the secret name passed via --secret (default: golfbox-mcp-tokens).
+
+After this runs successfully:
+- Set GOLF_DATA_SOURCE=mcp on the golf-scraper Lambda
+- Ensure the Lambda execution role has secretsmanager:GetSecretValue and
+  secretsmanager:UpdateSecret on the secret ARN
+
+Usage:
+    AWS_PROFILE=tennis-bot uv run python scripts/golfbox_mcp_oauth_setup.py
+"""
+
+import argparse
+import base64
+import hashlib
+import http.server
+import json
+import os
+import secrets
+import ssl
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+import urllib.parse
+import urllib.request
+import webbrowser
+
+ISSUER = "https://mcp.vardenlab.com"
+REGISTER_URL = f"{ISSUER}/api/oauth/register"
+AUTHORIZE_URL = f"{ISSUER}/api/oauth/authorize"
+TOKEN_URL = f"{ISSUER}/api/oauth/token"
+# RFC 8707 resource indicator — the canonical MCP resource URI. Vardenlab's
+# authorize + token endpoints require it ("invalid_target" otherwise). Value
+# comes from /.well-known/oauth-protected-resource/api/mcp/golfbox.
+RESOURCE = f"{ISSUER}/api/mcp/golfbox"
+# Vardenlab rejects http loopback redirects in production ("redirect_uri must
+# use https://"), so the local callback server must speak TLS. See
+# _make_tls_callback_server for the self-signed-cert workaround.
+REDIRECT_URI = "https://127.0.0.1:8765/callback"
+SCOPE = "read write"
+
+_callback = {"code": None, "state": None, "error": None}
+
+
+def _make_tls_callback_server(handler):
+    """Build an https loopback callback server with an ephemeral self-signed cert.
+
+    Vardenlab's OAuth server only string-matches redirect_uri; it never connects
+    to the loopback address itself — the browser performs the redirect. So a
+    throwaway self-signed cert (which the user click-throughs in the browser) is
+    sufficient and safe for this one-shot local handshake.
+    """
+    server = http.server.HTTPServer(("127.0.0.1", 8765), handler)
+    certdir = tempfile.mkdtemp(prefix="golfbox_mcp_tls_")
+    cert_path = os.path.join(certdir, "cert.pem")
+    key_path = os.path.join(certdir, "key.pem")
+    subprocess.run(
+        [
+            "openssl", "req", "-x509", "-newkey", "rsa:2048", "-nodes",
+            "-keyout", key_path, "-out", cert_path, "-days", "1",
+            "-subj", "/CN=127.0.0.1",
+            "-addext", "subjectAltName=IP:127.0.0.1",
+        ],
+        check=True,
+        capture_output=True,
+    )
+    ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    ctx.load_cert_chain(cert_path, key_path)
+    server.socket = ctx.wrap_socket(server.socket, server_side=True)
+    return server
+
+
+class CallbackHandler(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        parsed = urllib.parse.urlparse(self.path)
+        params = urllib.parse.parse_qs(parsed.query)
+        _callback["code"] = params.get("code", [None])[0]
+        _callback["state"] = params.get("state", [None])[0]
+        _callback["error"] = params.get("error", [None])[0]
+        self.send_response(200)
+        self.send_header("Content-Type", "text/html; charset=utf-8")
+        self.end_headers()
+        if _callback["error"]:
+            self.wfile.write(f"<h1>Feil: {_callback['error']}</h1>".encode())
+        else:
+            self.wfile.write(b"<h1>OK - lukk dette vinduet</h1>")
+
+    def log_message(self, *args, **kwargs):
+        pass
+
+
+def _b64url(data):
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode()
+
+
+def register_client():
+    print("[1/4] Registrerer ny OAuth-klient hos Vardenlab...")
+    body = json.dumps({
+        "client_name": "tennis-bot-golf-scraper",
+        "redirect_uris": [REDIRECT_URI],
+        "grant_types": ["authorization_code", "refresh_token"],
+        "response_types": ["code"],
+        "token_endpoint_auth_method": "none",
+    }).encode()
+    req = urllib.request.Request(REGISTER_URL, data=body, method="POST")
+    req.add_header("Content-Type", "application/json")
+    with urllib.request.urlopen(req, timeout=15) as resp:
+        data = json.loads(resp.read())
+    print(f"      client_id = {data['client_id']}")
+    return data
+
+
+def run_auth_flow(client_id):
+    print("[2/4] Starter PKCE auth-code flow...")
+    verifier = _b64url(secrets.token_bytes(32))
+    challenge = _b64url(hashlib.sha256(verifier.encode()).digest())
+    state = secrets.token_urlsafe(16)
+    qs = urllib.parse.urlencode({
+        "response_type": "code",
+        "client_id": client_id,
+        "redirect_uri": REDIRECT_URI,
+        "scope": SCOPE,
+        "code_challenge": challenge,
+        "code_challenge_method": "S256",
+        "state": state,
+        "resource": RESOURCE,
+    })
+    url = f"{AUTHORIZE_URL}?{qs}"
+
+    server = _make_tls_callback_server(CallbackHandler)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    print("      Åpner nettleser. Klikk godkjenn.")
+    print(f"      Fallback-URL: {url}")
+    print()
+    print("      VIKTIG: callback-serveren bruker et selvsignert TLS-sertifikat.")
+    print("      Nettleseren vil vise en sikkerhetsadvarsel på slutten —")
+    print("      klikk 'Avansert' → 'Fortsett til 127.0.0.1' (Chrome: skriv")
+    print("      'thisisunsafe' på siden). Dette er trygt for dette engangsoppsettet.")
+    webbrowser.open(url)
+
+    deadline = time.time() + 600
+    while time.time() < deadline and _callback["code"] is None and _callback["error"] is None:
+        time.sleep(1)
+    server.shutdown()
+
+    if _callback["error"]:
+        sys.exit(f"OAuth-feil: {_callback['error']}")
+    if not _callback["code"]:
+        sys.exit("Timeout - ingen callback innen 5 min")
+    if _callback["state"] != state:
+        sys.exit(f"State mismatch: {_callback['state']} != {state}")
+    return _callback["code"], verifier
+
+
+def exchange_code(client_id, code, verifier):
+    print("[3/4] Bytter auth-code mot refresh token...")
+    form = urllib.parse.urlencode({
+        "grant_type": "authorization_code",
+        "code": code,
+        "redirect_uri": REDIRECT_URI,
+        "client_id": client_id,
+        "code_verifier": verifier,
+        "resource": RESOURCE,
+    }).encode()
+    req = urllib.request.Request(TOKEN_URL, data=form, method="POST")
+    req.add_header("Content-Type", "application/x-www-form-urlencoded")
+    req.add_header("Accept", "application/json")
+    with urllib.request.urlopen(req, timeout=15) as resp:
+        tokens = json.loads(resp.read())
+    if "refresh_token" not in tokens:
+        sys.exit(f"Ingen refresh_token i respons: {tokens}")
+    print(f"      Mottatt access_token + refresh_token (scope={tokens.get('scope')})")
+    return tokens
+
+
+def write_secret(secret_name, region, profile, client, tokens):
+    print(f"[4/4] Skriver til Secrets Manager: {secret_name} (region={region})...")
+    import boto3
+    session_kwargs = {"region_name": region}
+    if profile:
+        session_kwargs["profile_name"] = profile
+    session = boto3.Session(**session_kwargs)
+    sm = session.client("secretsmanager")
+
+    payload = json.dumps({
+        "client_id": client["client_id"],
+        "client_secret": client.get("client_secret"),
+        "refresh_token": tokens["refresh_token"],
+    })
+    try:
+        sm.update_secret(SecretId=secret_name, SecretString=payload)
+        print("      Oppdaterte eksisterende secret")
+    except sm.exceptions.ResourceNotFoundException:
+        sm.create_secret(
+            Name=secret_name,
+            Description="Vardenlab MCP OAuth tokens for golf-scraper Lambda",
+            SecretString=payload,
+        )
+        print("      Opprettet ny secret")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--secret", default="golfbox-mcp-tokens")
+    ap.add_argument("--region", default="eu-north-1")
+    ap.add_argument("--profile", default="tennis-bot")
+    args = ap.parse_args()
+
+    client = register_client()
+    code, verifier = run_auth_flow(client["client_id"])
+    tokens = exchange_code(client["client_id"], code, verifier)
+    write_secret(args.secret, args.region, args.profile, client, tokens)
+
+    print()
+    print("FERDIG. Neste steg:")
+    print(f"  1. Sett env-var: GOLF_DATA_SOURCE=mcp på golf-scraper Lambda")
+    print(f"  2. Sett env-var: MCP_TOKEN_SECRET={args.secret} (om annet enn default)")
+    print(f"  3. Sørg for IAM-policy: secretsmanager:GetSecretValue + UpdateSecret")
+    print(f"     på arn:aws:secretsmanager:{args.region}:*:secret:{args.secret}*")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/golfbox_mcp_poc.py
+++ b/scripts/golfbox_mcp_poc.py
@@ -1,0 +1,300 @@
+"""End-to-end PoC: OAuth handshake + MCP tool call against Vardenlab's GolfBox MCP.
+
+Validates assumptions before pivoting Lambda to MCP:
+- Dynamic client registration works (no pre-issued client secret needed)
+- PKCE auth-code flow with loopback redirect succeeds
+- MCP streamable-HTTP transport: initialize -> notifications/initialized -> tools/call
+- Bearer token from token endpoint works against /api/mcp/golfbox
+- search_tee_times for Onsoy 2026-05-25 returns 845,- (member view)
+
+Run locally:
+    uv run python scripts/golfbox_mcp_poc.py
+"""
+
+import base64
+import hashlib
+import http.server
+import json
+import os
+import secrets
+import ssl
+import subprocess
+import tempfile
+import threading
+import time
+import urllib.parse
+import urllib.request
+import webbrowser
+
+ISSUER = "https://mcp.vardenlab.com"
+MCP_URL = "https://mcp.vardenlab.com/api/mcp/golfbox"
+REGISTER_URL = f"{ISSUER}/api/oauth/register"
+AUTHORIZE_URL = f"{ISSUER}/api/oauth/authorize"
+TOKEN_URL = f"{ISSUER}/api/oauth/token"
+# Vardenlab rejects http loopback redirects in production ("redirect_uri must
+# use https://"), so the local callback server must speak TLS. See
+# _make_tls_callback_server for the self-signed-cert workaround.
+REDIRECT_URI = "https://127.0.0.1:8765/callback"
+SCOPE = "read write"
+
+_callback_code = {"value": None, "state": None}
+
+
+def _make_tls_callback_server(handler):
+    """Build an https loopback callback server with an ephemeral self-signed cert.
+
+    Vardenlab's OAuth server only string-matches redirect_uri; it never connects
+    to the loopback address itself — the browser performs the redirect. So a
+    throwaway self-signed cert (which the user click-throughs in the browser) is
+    sufficient and safe for this one-shot local handshake.
+    """
+    server = http.server.HTTPServer(("127.0.0.1", 8765), handler)
+    certdir = tempfile.mkdtemp(prefix="golfbox_mcp_tls_")
+    cert_path = os.path.join(certdir, "cert.pem")
+    key_path = os.path.join(certdir, "key.pem")
+    subprocess.run(
+        [
+            "openssl", "req", "-x509", "-newkey", "rsa:2048", "-nodes",
+            "-keyout", key_path, "-out", cert_path, "-days", "1",
+            "-subj", "/CN=127.0.0.1",
+            "-addext", "subjectAltName=IP:127.0.0.1",
+        ],
+        check=True,
+        capture_output=True,
+    )
+    ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    ctx.load_cert_chain(cert_path, key_path)
+    server.socket = ctx.wrap_socket(server.socket, server_side=True)
+    return server
+
+
+class CallbackHandler(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        parsed = urllib.parse.urlparse(self.path)
+        params = urllib.parse.parse_qs(parsed.query)
+        _callback_code["value"] = params.get("code", [None])[0]
+        _callback_code["state"] = params.get("state", [None])[0]
+        self.send_response(200)
+        self.send_header("Content-Type", "text/html")
+        self.end_headers()
+        self.wfile.write(b"<h1>OK - lukk dette vinduet</h1>")
+
+    def log_message(self, *args, **kwargs):
+        pass
+
+
+def _b64url(data):
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode()
+
+
+def _http_post_json(url, payload, headers=None):
+    body = json.dumps(payload).encode()
+    req = urllib.request.Request(url, data=body, method="POST")
+    req.add_header("Content-Type", "application/json")
+    req.add_header("Accept", "application/json, text/event-stream")
+    for k, v in (headers or {}).items():
+        req.add_header(k, v)
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        return resp.status, dict(resp.headers), resp.read()
+
+
+def _http_post_form(url, form, headers=None):
+    body = urllib.parse.urlencode(form).encode()
+    req = urllib.request.Request(url, data=body, method="POST")
+    req.add_header("Content-Type", "application/x-www-form-urlencoded")
+    req.add_header("Accept", "application/json")
+    for k, v in (headers or {}).items():
+        req.add_header(k, v)
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        return json.loads(resp.read())
+
+
+def register_client():
+    print("[1/5] Registrerer dynamisk OAuth-klient...")
+    status, _, body = _http_post_json(REGISTER_URL, {
+        "client_name": "tennis-bot-golf-scraper",
+        "redirect_uris": [REDIRECT_URI],
+        "grant_types": ["authorization_code", "refresh_token"],
+        "response_types": ["code"],
+        "token_endpoint_auth_method": "none",
+    })
+    if status not in (200, 201):
+        raise RuntimeError(f"Register failed: {status}")
+    data = json.loads(body)
+    print(f"      client_id = {data['client_id']}")
+    return data["client_id"]
+
+
+def authorize(client_id):
+    print("[2/5] Starter PKCE auth-code flow...")
+    code_verifier = _b64url(secrets.token_bytes(32))
+    code_challenge = _b64url(hashlib.sha256(code_verifier.encode()).digest())
+    state = secrets.token_urlsafe(16)
+    params = {
+        "response_type": "code",
+        "client_id": client_id,
+        "redirect_uri": REDIRECT_URI,
+        "scope": SCOPE,
+        "code_challenge": code_challenge,
+        "code_challenge_method": "S256",
+        "state": state,
+        # RFC 8707 resource indicator — Vardenlab's authorize endpoint requires
+        # it ("invalid_target: At least one resource ... is required").
+        "resource": MCP_URL,
+    }
+    url = f"{AUTHORIZE_URL}?{urllib.parse.urlencode(params)}"
+
+    server = _make_tls_callback_server(CallbackHandler)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+
+    print(f"      Åpner nettleser. Godkjenn så lukker scriptet seg.")
+    print(f"      Hvis nettleseren ikke åpner: gå til {url}")
+    print()
+    print("      VIKTIG: callback-serveren bruker et selvsignert TLS-sertifikat.")
+    print("      Nettleseren vil vise en sikkerhetsadvarsel på slutten —")
+    print("      klikk 'Avansert' → 'Fortsett til 127.0.0.1' (Chrome: skriv")
+    print("      'thisisunsafe' på siden). Dette er trygt for dette engangsoppsettet.")
+    webbrowser.open(url)
+
+    for _ in range(600):
+        if _callback_code["value"]:
+            break
+        time.sleep(1)
+    server.shutdown()
+
+    if not _callback_code["value"]:
+        raise RuntimeError("Ingen callback innen 10 min")
+    if _callback_code["state"] != state:
+        raise RuntimeError(f"State mismatch: {_callback_code['state']} != {state}")
+    print(f"      Mottok code (len={len(_callback_code['value'])})")
+    return _callback_code["value"], code_verifier
+
+
+def exchange_code(client_id, code, verifier):
+    print("[3/5] Bytter auth-code mot access+refresh token...")
+    tokens = _http_post_form(TOKEN_URL, {
+        "grant_type": "authorization_code",
+        "code": code,
+        "redirect_uri": REDIRECT_URI,
+        "client_id": client_id,
+        "code_verifier": verifier,
+        "resource": MCP_URL,
+    })
+    if "access_token" not in tokens:
+        raise RuntimeError(f"Token exchange failed: {tokens}")
+    print(f"      access_token (preview): {tokens['access_token'][:20]}...")
+    print(f"      refresh_token (preview): {tokens.get('refresh_token','<none>')[:20]}...")
+    print(f"      expires_in: {tokens.get('expires_in')}")
+    return tokens
+
+
+def mcp_call(access_token, method, params=None, request_id=1, session_id=None):
+    body = {"jsonrpc": "2.0", "id": request_id, "method": method}
+    if params is not None:
+        body["params"] = params
+    headers = {"Authorization": f"Bearer {access_token}"}
+    if session_id:
+        headers["Mcp-Session-Id"] = session_id
+    status, resp_headers, raw = _http_post_json(MCP_URL, body, headers=headers)
+    # Streamable-HTTP can return either application/json or event-stream
+    ctype = resp_headers.get("content-type", resp_headers.get("Content-Type", ""))
+    new_session = resp_headers.get("mcp-session-id", resp_headers.get("Mcp-Session-Id"))
+    if "event-stream" in ctype:
+        # Parse SSE: lines starting with "data: " followed by JSON
+        text = raw.decode()
+        for line in text.split("\n"):
+            if line.startswith("data:"):
+                payload = json.loads(line[5:].strip())
+                return status, new_session, payload
+        raise RuntimeError(f"SSE response with no data line: {text[:300]}")
+    return status, new_session, json.loads(raw)
+
+
+def mcp_notify(access_token, method, params=None, session_id=None):
+    body = {"jsonrpc": "2.0", "method": method}
+    if params is not None:
+        body["params"] = params
+    headers = {"Authorization": f"Bearer {access_token}"}
+    if session_id:
+        headers["Mcp-Session-Id"] = session_id
+    status, _, _ = _http_post_json(MCP_URL, body, headers=headers)
+    return status
+
+
+def initialize_mcp(access_token):
+    print("[4/5] MCP initialize...")
+    status, session_id, resp = mcp_call(
+        access_token,
+        "initialize",
+        params={
+            "protocolVersion": "2025-03-26",
+            "capabilities": {},
+            "clientInfo": {"name": "tennis-bot-poc", "version": "0.1.0"},
+        },
+        request_id=1,
+    )
+    print(f"      status={status}, session_id={session_id}")
+    if "error" in resp:
+        raise RuntimeError(f"Initialize failed: {resp}")
+    server_info = resp.get("result", {}).get("serverInfo", {})
+    print(f"      server: {server_info}")
+    print("      Sender notifications/initialized...")
+    mcp_notify(access_token, "notifications/initialized", session_id=session_id)
+    return session_id
+
+
+def search_onsoy(access_token, session_id):
+    print("[5/5] Kaller search_tee_times for Onsoy 2026-05-25...")
+    status, _, resp = mcp_call(
+        access_token,
+        "tools/call",
+        params={
+            "name": "search_tee_times",
+            "arguments": {"club": "onsoy", "date": "2026-05-25", "only_free": True},
+        },
+        request_id=2,
+        session_id=session_id,
+    )
+    if "error" in resp:
+        raise RuntimeError(f"Tool call failed: {resp}")
+    content = resp.get("result", {}).get("content", [])
+    if not content:
+        raise RuntimeError(f"Empty content in response: {resp}")
+    text_payload = content[0].get("text", "")
+    slots = json.loads(text_payload)
+    print(f"      Antall slots: {len(slots)}")
+    prices = [s["raw_label"][-6:] for s in slots if s.get("raw_label")]
+    has_845 = any("845" in p for p in prices)
+    has_795 = any("795" in p for p in prices)
+    print(f"      Inneholder 845,-: {has_845}")
+    print(f"      Inneholder 795,-: {has_795}  (skal vaere False for member view)")
+    return slots
+
+
+def main():
+    client_id = register_client()
+    code, verifier = authorize(client_id)
+    tokens = exchange_code(client_id, code, verifier)
+    session_id = initialize_mcp(tokens["access_token"])
+    slots = search_onsoy(tokens["access_token"], session_id)
+
+    print()
+    print("=" * 60)
+    print("POC SUKSESS - lagrer refresh_token + client_id til /tmp/golfbox_mcp_tokens.json")
+    print("=" * 60)
+    with open("/tmp/golfbox_mcp_tokens.json", "w") as f:
+        json.dump({
+            "client_id": client_id,
+            "refresh_token": tokens.get("refresh_token"),
+            "access_token_preview": tokens["access_token"][:30],
+            "scope": tokens.get("scope"),
+            "saved_at": int(time.time()),
+        }, f, indent=2)
+    print()
+    print("MERK: dette var KUN validering — ingenting ble skrevet til AWS.")
+    print("For å gi Lambdaen en token, kjør provisjonerings-scriptet:")
+    print("  AWS_PROFILE=tennis-bot uv run python scripts/golfbox_mcp_oauth_setup.py")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_golf_mcp.py
+++ b/tests/test_golf_mcp.py
@@ -605,3 +605,50 @@ class TestFetchSlotsViaScrape:
             lambda _: None,
         )
         assert result is None
+
+
+class TestMcpAuthCircuitBreaker:
+    """Regression for the 2026-05-21 incident: a broken OAuth chain must not
+    retry every facility+date and hammer the token endpoint into 429s."""
+
+    def _run_with_failing_mcp(self, n_facilities, limit):
+        import facilities as facilities_mod
+        handler = _load_golf_handler()
+        import mcp_client
+
+        handler.GOLF_DATA_SOURCE = "mcp"
+        handler.MCP_AUTH_FAILURE_LIMIT = limit
+        handler.DAYS_AHEAD = 14  # 14 dates per facility → 14*n potential calls
+
+        facs = {f"club{i}": {"sports": ["golf"]} for i in range(n_facilities)}
+        calls = {"n": 0}
+
+        def always_auth_fail(cfg, date_str):
+            calls["n"] += 1
+            raise mcp_client.MCPAuthError("simulated invalid_grant")
+
+        with patch.object(facilities_mod, "get_facilities_for_sport", return_value=facs), \
+             patch.object(facilities_mod, "get_golfbox_config",
+                          return_value={"mcp_slug": "x"}), \
+             patch.object(handler, "_get_dynamodb", return_value=MagicMock()), \
+             patch.object(handler, "_load_previous_snapshot", return_value={}), \
+             patch.object(handler, "_save_snapshot"), \
+             patch.object(handler, "_invoke_notifications"), \
+             patch.object(handler, "_fetch_slots_via_mcp", side_effect=always_auth_fail):
+            resp = handler.lambda_handler({}, None)
+        return calls["n"], resp
+
+    def test_aborts_after_limit_not_all_dates(self):
+        # 3 facilities * 14 dates = 42 potential calls; breaker must stop at 3.
+        n_calls, resp = self._run_with_failing_mcp(n_facilities=3, limit=3)
+        assert n_calls == 3
+        body = json.loads(resp["body"])
+        assert body["authAborted"] is True
+        assert body["authFailures"] == 3
+        assert body["totalSlots"] == 0
+
+    def test_limit_of_one_aborts_immediately(self):
+        n_calls, resp = self._run_with_failing_mcp(n_facilities=2, limit=1)
+        assert n_calls == 1
+        body = json.loads(resp["body"])
+        assert body["authAborted"] is True

--- a/tests/test_golf_mcp.py
+++ b/tests/test_golf_mcp.py
@@ -652,3 +652,93 @@ class TestMcpAuthCircuitBreaker:
         assert n_calls == 1
         body = json.loads(resp["body"])
         assert body["authAborted"] is True
+
+
+class TestMcpRunLock:
+    """The MCP path must run one-at-a-time — two concurrent invocations sharing
+    the rotating Vardenlab refresh token revoke each other's token family
+    (2026-05-21 incident). Reserved concurrency=1 is unavailable on this
+    account, so a DynamoDB conditional-write lock serializes runs instead."""
+
+    def test_acquire_returns_true_when_put_succeeds(self):
+        handler = _load_golf_handler()
+        table = MagicMock()
+        with patch.object(handler, "_get_dynamodb") as mock_db:
+            mock_db.return_value.Table.return_value = table
+            assert handler._acquire_run_lock() is True
+        # Conditional write guards against an existing live lock.
+        _, kwargs = table.put_item.call_args
+        assert "attribute_not_exists" in kwargs["ConditionExpression"]
+        assert kwargs["Item"]["sessionId"] == handler.RUN_LOCK_KEY
+
+    def test_acquire_returns_false_when_lock_held(self):
+        from botocore.exceptions import ClientError
+        handler = _load_golf_handler()
+        table = MagicMock()
+        table.put_item.side_effect = ClientError(
+            {"Error": {"Code": "ConditionalCheckFailedException"}}, "PutItem",
+        )
+        with patch.object(handler, "_get_dynamodb") as mock_db:
+            mock_db.return_value.Table.return_value = table
+            assert handler._acquire_run_lock() is False
+
+    def test_acquire_reraises_unexpected_client_error(self):
+        from botocore.exceptions import ClientError
+        handler = _load_golf_handler()
+        table = MagicMock()
+        table.put_item.side_effect = ClientError(
+            {"Error": {"Code": "ProvisionedThroughputExceededException"}}, "PutItem",
+        )
+        with patch.object(handler, "_get_dynamodb") as mock_db:
+            mock_db.return_value.Table.return_value = table
+            with pytest.raises(ClientError):
+                handler._acquire_run_lock()
+
+    def test_release_deletes_lock_item(self):
+        handler = _load_golf_handler()
+        table = MagicMock()
+        with patch.object(handler, "_get_dynamodb") as mock_db:
+            mock_db.return_value.Table.return_value = table
+            handler._release_run_lock()
+        table.delete_item.assert_called_once_with(Key={"sessionId": handler.RUN_LOCK_KEY})
+
+    def test_handler_skips_when_lock_held(self):
+        handler = _load_golf_handler()
+        handler.GOLF_DATA_SOURCE = "mcp"
+        with patch.object(handler, "_acquire_run_lock", return_value=False), \
+             patch.object(handler, "_release_run_lock") as mock_release, \
+             patch.object(handler, "_run_scrape") as mock_run:
+            resp = handler.lambda_handler({}, None)
+        assert json.loads(resp["body"])["skipped"] == "locked"
+        mock_run.assert_not_called()
+        mock_release.assert_not_called()
+
+    def test_handler_releases_lock_after_mcp_run(self):
+        handler = _load_golf_handler()
+        handler.GOLF_DATA_SOURCE = "mcp"
+        with patch.object(handler, "_acquire_run_lock", return_value=True) as mock_acq, \
+             patch.object(handler, "_release_run_lock") as mock_release, \
+             patch.object(handler, "_run_scrape", return_value={"statusCode": 200, "body": "{}"}):
+            handler.lambda_handler({}, None)
+        mock_acq.assert_called_once()
+        mock_release.assert_called_once()
+
+    def test_handler_releases_lock_even_when_run_raises(self):
+        handler = _load_golf_handler()
+        handler.GOLF_DATA_SOURCE = "mcp"
+        with patch.object(handler, "_acquire_run_lock", return_value=True), \
+             patch.object(handler, "_release_run_lock") as mock_release, \
+             patch.object(handler, "_run_scrape", side_effect=RuntimeError("boom")):
+            with pytest.raises(RuntimeError):
+                handler.lambda_handler({}, None)
+        mock_release.assert_called_once()
+
+    def test_scrape_mode_does_not_touch_lock(self):
+        handler = _load_golf_handler()
+        handler.GOLF_DATA_SOURCE = "scrape"
+        with patch.object(handler, "_acquire_run_lock") as mock_acq, \
+             patch.object(handler, "_release_run_lock") as mock_release, \
+             patch.object(handler, "_run_scrape", return_value={"statusCode": 200, "body": "{}"}):
+            handler.lambda_handler({}, None)
+        mock_acq.assert_not_called()
+        mock_release.assert_not_called()

--- a/tests/test_golf_mcp.py
+++ b/tests/test_golf_mcp.py
@@ -1,0 +1,607 @@
+"""Tests for the MCP path of golf-scraper (mcp_to_slots + mcp_client)."""
+import importlib
+import json
+import os
+import sys
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+_GOLF_SCRAPER_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    "lambdas",
+    "golf-scraper",
+)
+sys.path.insert(0, _GOLF_SCRAPER_DIR)
+
+
+def _load_golf_handler():
+    """Force-load the golf-scraper handler module.
+
+    Multiple lambdas have a top-level handler.py; pytest's shared module cache
+    means whichever test file imports `handler` first wins. Pop and reload so
+    we always get the golf one when this test file runs.
+    """
+    for mod in ("handler", "parser", "scraper", "mcp_client", "mcp_to_slots"):
+        sys.modules.pop(mod, None)
+    if _GOLF_SCRAPER_DIR not in sys.path:
+        sys.path.insert(0, _GOLF_SCRAPER_DIR)
+    elif sys.path[0] != _GOLF_SCRAPER_DIR:
+        sys.path.remove(_GOLF_SCRAPER_DIR)
+        sys.path.insert(0, _GOLF_SCRAPER_DIR)
+    return importlib.import_module("handler")
+
+
+# --- mcp_to_slots tests ----------------------------------------------------
+
+
+class TestExtractTimeKey:
+    def test_basic_iso(self):
+        from mcp_to_slots import _extract_time_key
+        assert _extract_time_key("2026-05-25T07:09:00") == "07:09"
+
+    def test_late_hour(self):
+        from mcp_to_slots import _extract_time_key
+        assert _extract_time_key("2026-05-25T23:59:00") == "23:59"
+
+    def test_none_input(self):
+        from mcp_to_slots import _extract_time_key
+        assert _extract_time_key(None) is None
+
+    def test_no_t_separator(self):
+        from mcp_to_slots import _extract_time_key
+        assert _extract_time_key("2026-05-25 07:09:00") is None
+
+    def test_malformed_short(self):
+        from mcp_to_slots import _extract_time_key
+        assert _extract_time_key("2026-05-25T07") is None
+
+    def test_missing_colon(self):
+        from mcp_to_slots import _extract_time_key
+        assert _extract_time_key("2026-05-25T0709:00") is None
+
+
+class TestExtractPrice:
+    def test_handicap_merged_price(self):
+        from mcp_to_slots import _extract_price
+        # ",N(NNN)" — last digit before is single handicap decimal
+        assert _extract_price("Spiller A hcp:21,7845,-") == "845,-"
+
+    def test_handicap_merged_price_four_digit(self):
+        from mcp_to_slots import _extract_price
+        assert _extract_price("Spiller A hcp:21,71095,-") == "1095,-"
+
+    def test_bare_three_digit_price(self):
+        from mcp_to_slots import _extract_price
+        assert _extract_price("845,-") == "845,-"
+
+    def test_bare_four_digit_price(self):
+        from mcp_to_slots import _extract_price
+        assert _extract_price("1095,-") == "1095,-"
+
+    def test_five_digit_merged_hhmm_plus_three(self):
+        from mcp_to_slots import _extract_price
+        # "07:00845" → time + 3-digit price
+        assert _extract_price("07:00845") == "845,-"
+
+    def test_six_digit_merged_hhmm_plus_four(self):
+        from mcp_to_slots import _extract_price
+        # "07:001095" → time + 4-digit price
+        assert _extract_price("07:001095") == "1095,-"
+
+    def test_six_digit_leading_zero_rejected(self):
+        from mcp_to_slots import _extract_price
+        # last4 starts with 0 → reject
+        assert _extract_price("07:000845") is None
+
+    def test_empty_label(self):
+        from mcp_to_slots import _extract_price
+        assert _extract_price("") is None
+
+    def test_none_label(self):
+        from mcp_to_slots import _extract_price
+        assert _extract_price(None) is None
+
+    def test_no_digits(self):
+        from mcp_to_slots import _extract_price
+        assert _extract_price("Spiller A") is None
+
+
+class TestSpotsAvailable:
+    def test_free_returns_full_capacity(self):
+        from mcp_to_slots import _spots_available, TEE_CAPACITY
+        assert _spots_available({"status": "free"}) == TEE_CAPACITY
+
+    def test_full_returns_zero(self):
+        from mcp_to_slots import _spots_available
+        assert _spots_available({"status": "full"}) == 0
+
+    def test_tournament_returns_zero(self):
+        from mcp_to_slots import _spots_available
+        assert _spots_available({"status": "tournament"}) == 0
+
+    def test_partial_with_booked(self):
+        from mcp_to_slots import _spots_available
+        assert _spots_available({"status": "partial", "capacity": 4, "booked": 1}) == 3
+
+    def test_partial_full_capacity(self):
+        from mcp_to_slots import _spots_available
+        assert _spots_available({"status": "partial", "capacity": 4, "booked": 4}) == 0
+
+    def test_partial_default_capacity(self):
+        from mcp_to_slots import _spots_available
+        assert _spots_available({"status": "partial", "booked": 2}) == 2
+
+    def test_partial_no_booked_falls_back_to_players(self):
+        from mcp_to_slots import _spots_available
+        slot = {"status": "partial", "capacity": 4, "players": [{"n": "A"}, {"n": "B"}]}
+        assert _spots_available(slot) == 2
+
+    def test_partial_no_booked_no_players_defaults_to_one_booked(self):
+        from mcp_to_slots import _spots_available
+        assert _spots_available({"status": "partial", "capacity": 4}) == 3
+
+
+class TestMcpSlotsToDict:
+    def test_free_slot_full_capacity(self):
+        from mcp_to_slots import mcp_slots_to_dict
+        slots = [{
+            "start": "2026-05-25T07:00:00",
+            "status": "free",
+            "raw_label": "07:00845,-",
+        }]
+        result = mcp_slots_to_dict(slots)
+        assert result == {"07:00": ["4 spots (845,-)"]}
+
+    def test_partial_with_booked(self):
+        from mcp_to_slots import mcp_slots_to_dict
+        slots = [{
+            "start": "2026-05-25T07:09:00",
+            "status": "partial",
+            "capacity": 4,
+            "booked": 3,
+            "raw_label": "07:09845,-",
+        }]
+        result = mcp_slots_to_dict(slots)
+        assert result == {"07:09": ["1 spot (845,-)"]}
+
+    def test_blocked_skipped(self):
+        from mcp_to_slots import mcp_slots_to_dict
+        slots = [
+            {"start": "2026-05-25T07:00:00", "status": "tournament", "raw_label": "x"},
+            {"start": "2026-05-25T07:09:00", "status": "closed", "raw_label": "x"},
+            {"start": "2026-05-25T07:18:00", "status": "blocked", "raw_label": "x"},
+            {"start": "2026-05-25T07:27:00", "status": "expired", "raw_label": "x"},
+            {"start": "2026-05-25T07:36:00", "status": "too_far_ahead", "raw_label": "x"},
+            {"start": "2026-05-25T07:45:00", "status": "full", "raw_label": "x"},
+        ]
+        assert mcp_slots_to_dict(slots) == {}
+
+    def test_multiple_slots_same_time_combined(self):
+        from mcp_to_slots import mcp_slots_to_dict
+        slots = [
+            {
+                "start": "2026-05-25T07:00:00",
+                "status": "free",
+                "raw_label": "07:00845,-",
+            },
+            {
+                "start": "2026-05-25T07:00:00",
+                "status": "partial",
+                "capacity": 4,
+                "booked": 2,
+                "raw_label": "07:00845,-",
+            },
+        ]
+        result = mcp_slots_to_dict(slots)
+        assert sorted(result["07:00"]) == sorted(["4 spots (845,-)", "2 spots (845,-)"])
+
+    def test_partial_with_zero_spots_dropped(self):
+        from mcp_to_slots import mcp_slots_to_dict
+        slots = [{
+            "start": "2026-05-25T07:00:00",
+            "status": "partial",
+            "capacity": 4,
+            "booked": 4,
+            "raw_label": "07:00845,-",
+        }]
+        assert mcp_slots_to_dict(slots) == {}
+
+    def test_price_missing_uses_count_only(self):
+        from mcp_to_slots import mcp_slots_to_dict
+        slots = [{
+            "start": "2026-05-25T07:00:00",
+            "status": "free",
+            "raw_label": "garbage",
+        }]
+        result = mcp_slots_to_dict(slots)
+        assert result == {"07:00": ["4 spots"]}
+
+    def test_singular_spot_grammar(self):
+        from mcp_to_slots import mcp_slots_to_dict
+        slots = [{
+            "start": "2026-05-25T07:00:00",
+            "status": "partial",
+            "capacity": 4,
+            "booked": 3,
+            "raw_label": "07:00845,-",
+        }]
+        result = mcp_slots_to_dict(slots)
+        assert result == {"07:00": ["1 spot (845,-)"]}
+
+    def test_unparseable_time_skipped(self):
+        from mcp_to_slots import mcp_slots_to_dict
+        slots = [{"start": "garbage", "status": "free", "raw_label": "07:00845"}]
+        assert mcp_slots_to_dict(slots) == {}
+
+
+# --- mcp_client tests ------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _reset_mcp_client():
+    """Clear module-level cache between tests."""
+    import mcp_client
+    mcp_client.reset_for_tests()
+    yield
+    mcp_client.reset_for_tests()
+
+
+def _mock_urlopen_response(body, headers=None, content_type="application/json"):
+    """Build a context-manager-compatible mock response.
+
+    Real dicts already have .get(); no need to wrap headers further.
+    """
+    resp = MagicMock()
+    resp.read.return_value = body.encode() if isinstance(body, str) else body
+    resp.headers = headers if headers is not None else {"Content-Type": content_type}
+    resp.__enter__ = lambda self: self
+    resp.__exit__ = lambda *a: None
+    return resp
+
+
+class TestRefreshAccessToken:
+    def test_refresh_caches_token(self):
+        import mcp_client
+
+        creds = {"client_id": "c1", "refresh_token": "rt1"}
+        with patch.object(mcp_client, "_load_credentials", return_value=creds), \
+             patch("urllib.request.urlopen") as mock_open:
+            mock_open.return_value = _mock_urlopen_response(
+                json.dumps({"access_token": "at1", "expires_in": 3600}),
+            )
+            mcp_client._refresh_access_token()
+
+        assert mcp_client._access_token == "at1"
+        assert mcp_client._access_expires_at > 0
+
+    def test_refresh_rotates_persisted_refresh_token(self):
+        import mcp_client
+
+        creds = {"client_id": "c1", "refresh_token": "rt1"}
+        with patch.object(mcp_client, "_load_credentials", return_value=creds), \
+             patch.object(mcp_client, "_persist_refresh_token") as mock_persist, \
+             patch("urllib.request.urlopen") as mock_open:
+            mock_open.return_value = _mock_urlopen_response(
+                json.dumps({
+                    "access_token": "at1",
+                    "expires_in": 3600,
+                    "refresh_token": "rt2",
+                }),
+            )
+            mcp_client._refresh_access_token()
+
+        mock_persist.assert_called_once_with("rt2")
+
+    def test_refresh_no_rotation_no_persist(self):
+        import mcp_client
+
+        creds = {"client_id": "c1", "refresh_token": "rt1"}
+        with patch.object(mcp_client, "_load_credentials", return_value=creds), \
+             patch.object(mcp_client, "_persist_refresh_token") as mock_persist, \
+             patch("urllib.request.urlopen") as mock_open:
+            mock_open.return_value = _mock_urlopen_response(
+                json.dumps({
+                    "access_token": "at1",
+                    "expires_in": 3600,
+                    "refresh_token": "rt1",
+                }),
+            )
+            mcp_client._refresh_access_token()
+
+        mock_persist.assert_not_called()
+
+    def test_refresh_no_access_token_raises_auth_error(self):
+        import mcp_client
+
+        creds = {"client_id": "c1", "refresh_token": "rt1"}
+        with patch.object(mcp_client, "_load_credentials", return_value=creds), \
+             patch("urllib.request.urlopen") as mock_open:
+            mock_open.return_value = _mock_urlopen_response(
+                json.dumps({"error": "invalid_grant"}),
+            )
+            with pytest.raises(mcp_client.MCPAuthError):
+                mcp_client._refresh_access_token()
+
+    def test_refresh_http_error_raises_auth_error(self):
+        import urllib.error
+        import mcp_client
+
+        creds = {"client_id": "c1", "refresh_token": "rt1"}
+        err = urllib.error.HTTPError("u", 400, "Bad", {}, None)
+        err.read = lambda: b'{"error":"invalid_grant"}'
+        with patch.object(mcp_client, "_load_credentials", return_value=creds), \
+             patch("urllib.request.urlopen", side_effect=err):
+            with pytest.raises(mcp_client.MCPAuthError):
+                mcp_client._refresh_access_token()
+
+
+class TestEnsureAccessToken:
+    def test_warm_token_reused(self):
+        import time as _time
+        import mcp_client
+
+        mcp_client._access_token = "warm"
+        mcp_client._access_expires_at = int(_time.time()) + 600
+
+        with patch.object(mcp_client, "_refresh_access_token") as mock_refresh:
+            token = mcp_client._ensure_access_token()
+
+        assert token == "warm"
+        mock_refresh.assert_not_called()
+
+    def test_expired_token_triggers_refresh(self):
+        import mcp_client
+
+        mcp_client._access_token = "old"
+        mcp_client._access_expires_at = 0
+
+        def fake_refresh():
+            mcp_client._access_token = "new"
+            mcp_client._access_expires_at = 10**12
+
+        with patch.object(mcp_client, "_refresh_access_token", side_effect=fake_refresh):
+            token = mcp_client._ensure_access_token()
+
+        assert token == "new"
+
+
+class TestPostJsonRpc:
+    def test_session_id_captured_from_header(self):
+        import mcp_client
+
+        mcp_client._access_token = "at"
+        mcp_client._access_expires_at = 10**12
+
+        resp = _mock_urlopen_response(
+            json.dumps({"jsonrpc": "2.0", "id": 1, "result": {}}),
+            headers={
+                "Content-Type": "application/json",
+                "Mcp-Session-Id": "sess-123",
+            },
+        )
+        with patch("urllib.request.urlopen", return_value=resp):
+            mcp_client._post_jsonrpc({"jsonrpc": "2.0", "id": 1, "method": "ping"})
+
+        assert mcp_client._session_id == "sess-123"
+
+    def test_sse_response_parsed(self):
+        import mcp_client
+
+        mcp_client._access_token = "at"
+        mcp_client._access_expires_at = 10**12
+
+        sse_body = (
+            "event: message\n"
+            'data: {"jsonrpc":"2.0","id":1,"result":{"ok":true}}\n\n'
+        )
+        resp = _mock_urlopen_response(
+            sse_body, headers={"Content-Type": "text/event-stream"},
+        )
+        with patch("urllib.request.urlopen", return_value=resp):
+            data = mcp_client._post_jsonrpc({"jsonrpc": "2.0", "id": 1, "method": "x"})
+
+        assert data["result"] == {"ok": True}
+
+    def test_401_raises_auth_error(self):
+        import urllib.error
+        import mcp_client
+
+        mcp_client._access_token = "at"
+        mcp_client._access_expires_at = 10**12
+
+        err = urllib.error.HTTPError("u", 401, "Unauth", {}, None)
+        err.read = lambda: b'{"error":"invalid_token"}'
+        with patch("urllib.request.urlopen", side_effect=err):
+            with pytest.raises(mcp_client.MCPAuthError):
+                mcp_client._post_jsonrpc({"jsonrpc": "2.0", "id": 1, "method": "x"})
+
+
+class TestSearchTeeTimes:
+    def test_calls_initialize_then_tool(self):
+        import mcp_client
+
+        mcp_client._access_token = "at"
+        mcp_client._access_expires_at = 10**12
+
+        # Three sequential urlopen calls: initialize, notifications/initialized,
+        # tools/call. The notifications call has expect_response=False so we
+        # don't strictly need to parse its body, but the handler still reads
+        # one response per urlopen — return empty JSON for it.
+        responses = [
+            _mock_urlopen_response(json.dumps({
+                "jsonrpc": "2.0", "id": 1,
+                "result": {"protocolVersion": "2025-03-26", "capabilities": {}},
+            })),
+            _mock_urlopen_response(json.dumps({})),
+            _mock_urlopen_response(json.dumps({
+                "jsonrpc": "2.0", "id": 99,
+                "result": {"content": [{"text": json.dumps([
+                    {"start": "2026-05-25T07:00:00", "status": "free",
+                     "raw_label": "07:00845,-"},
+                ])}]},
+            })),
+        ]
+        with patch("urllib.request.urlopen", side_effect=responses):
+            slots = mcp_client.search_tee_times("onsoy_gk", "2026-05-25")
+
+        assert slots == [
+            {"start": "2026-05-25T07:00:00", "status": "free",
+             "raw_label": "07:00845,-"},
+        ]
+
+    def test_401_triggers_refresh_and_retry(self):
+        import urllib.error
+        import mcp_client
+
+        mcp_client._access_token = "at"
+        mcp_client._access_expires_at = 10**12
+        mcp_client._initialized = True  # skip initialize on first attempt
+
+        err_401 = urllib.error.HTTPError("u", 401, "Unauth", {}, None)
+        err_401.read = lambda: b'{"error":"expired"}'
+
+        retry_responses = [
+            _mock_urlopen_response(json.dumps({
+                "jsonrpc": "2.0", "id": 1,
+                "result": {"protocolVersion": "2025-03-26", "capabilities": {}},
+            })),
+            _mock_urlopen_response(json.dumps({})),
+            _mock_urlopen_response(json.dumps({
+                "jsonrpc": "2.0", "id": 99,
+                "result": {"content": [{"text": json.dumps([])}]},
+            })),
+        ]
+
+        creds = {"client_id": "c1", "refresh_token": "rt1"}
+        with patch.object(mcp_client, "_load_credentials", return_value=creds), \
+             patch("urllib.request.urlopen") as mock_open:
+            mock_open.side_effect = [
+                err_401,  # first tool call → 401
+                _mock_urlopen_response(json.dumps({
+                    "access_token": "at2", "expires_in": 3600,
+                })),  # refresh
+                *retry_responses,  # initialize + initialized + tool
+            ]
+            slots = mcp_client.search_tee_times("onsoy_gk", "2026-05-25")
+
+        assert slots == []
+        assert mcp_client._access_token == "at2"
+
+    def test_auth_error_propagates_after_failed_refresh(self):
+        import urllib.error
+        import mcp_client
+
+        mcp_client._access_token = "at"
+        mcp_client._access_expires_at = 10**12
+        mcp_client._initialized = True
+
+        err_401 = urllib.error.HTTPError("u", 401, "Unauth", {}, None)
+        err_401.read = lambda: b'x'
+        refresh_err = urllib.error.HTTPError("u", 400, "Bad", {}, None)
+        refresh_err.read = lambda: b'x'
+
+        creds = {"client_id": "c1", "refresh_token": "rt1"}
+        with patch.object(mcp_client, "_load_credentials", return_value=creds), \
+             patch("urllib.request.urlopen") as mock_open:
+            mock_open.side_effect = [err_401, refresh_err]
+            with pytest.raises(mcp_client.MCPAuthError):
+                mcp_client.search_tee_times("onsoy_gk", "2026-05-25")
+
+
+# --- handler helper tests (data-source switch) -----------------------------
+
+
+class TestFetchSlotsViaMcp:
+    def test_returns_none_when_facility_lacks_slug(self):
+        handler = _load_golf_handler()
+        result = handler._fetch_slots_via_mcp({"resource_guid": "x"}, "2026-05-25")
+        assert result is None
+
+    def test_calls_search_tee_times_with_slug(self):
+        handler = _load_golf_handler()
+
+        with patch("mcp_client.search_tee_times") as mock_search:
+            mock_search.return_value = [{
+                "start": "2026-05-25T07:00:00",
+                "status": "free",
+                "raw_label": "07:00845,-",
+            }]
+            result = handler._fetch_slots_via_mcp(
+                {"mcp_slug": "onsoy_gk"}, "2026-05-25",
+            )
+
+        mock_search.assert_called_once_with("onsoy_gk", "2026-05-25", only_free=True)
+        assert result == {"07:00": ["4 spots (845,-)"]}
+
+    def test_auth_error_propagates_to_caller(self):
+        """Handler relies on this exception to bump auth_failures."""
+        handler = _load_golf_handler()
+        import mcp_client
+
+        with patch(
+            "mcp_client.search_tee_times",
+            side_effect=mcp_client.MCPAuthError("boom"),
+        ):
+            with pytest.raises(mcp_client.MCPAuthError):
+                handler._fetch_slots_via_mcp({"mcp_slug": "x"}, "2026-05-25")
+
+
+class TestFetchSlotsViaScrape:
+    def test_returns_parsed_slots_on_success(self):
+        handler = _load_golf_handler()
+
+        client = MagicMock()
+        client.fetch_grid.return_value = (
+            "<table><tr><td><span class='time'>07:00</span>Available</td></tr></table>"
+        )
+        client._logged_in = True
+
+        with patch("parser.parse_grid_html", return_value={"07:00": ["x"]}):
+            result = handler._fetch_slots_via_scrape(
+                client,
+                {"resource_guid": "r", "club_guid": "c"},
+                "2026-05-25",
+                lambda _: None,
+            )
+        assert result == {"07:00": ["x"]}
+
+    def test_session_expiry_triggers_relogin_and_retry(self):
+        handler = _load_golf_handler()
+
+        client = MagicMock()
+        # First fetch fails AND _logged_in is False → triggers re-login path.
+        client.fetch_grid.side_effect = [None, "<html/>"]
+        client._logged_in = False
+        client.login.return_value = True
+        client.cookies_dict = {"k": "v"}
+
+        cache_calls = []
+        with patch("parser.parse_grid_html", return_value={"07:00": []}):
+            result = handler._fetch_slots_via_scrape(
+                client,
+                {"resource_guid": "r", "club_guid": "c"},
+                "2026-05-25",
+                lambda c: cache_calls.append(c),
+            )
+
+        assert result == {"07:00": []}
+        client.login.assert_called_once()
+        assert cache_calls == [{"k": "v"}]
+
+    def test_returns_none_when_relogin_fails(self):
+        handler = _load_golf_handler()
+
+        client = MagicMock()
+        client.fetch_grid.return_value = None
+        client._logged_in = False
+        client.login.return_value = False
+
+        result = handler._fetch_slots_via_scrape(
+            client,
+            {"resource_guid": "r", "club_guid": "c"},
+            "2026-05-25",
+            lambda _: None,
+        )
+        assert result is None

--- a/tests/test_golf_scraper.py
+++ b/tests/test_golf_scraper.py
@@ -119,9 +119,11 @@ def test_golfbox_client_login_success(monkeypatch):
     import requests
 
     class MockResponse:
-        status_code = 302
+        status_code = 200
+        url = "https://www.golfbox.no/site/my_golfbox/myFrontPage.asp"
         headers = {"Location": "/site/my_golfbox/myFrontPage.asp"}
         cookies = requests.cookies.RequestsCookieJar()
+        text = "<html></html>"
 
     class MockSession:
         cookies = requests.cookies.RequestsCookieJar()
@@ -130,10 +132,7 @@ def test_golfbox_client_login_success(monkeypatch):
             return MockResponse()
 
         def get(self, *args, **kwargs):
-            resp = MockResponse()
-            resp.status_code = 200
-            resp.text = "<html></html>"
-            return resp
+            return MockResponse()
 
     client = GolfBoxClient(username="test", password="test")
     monkeypatch.setattr(client, "_session", MockSession())
@@ -218,13 +217,18 @@ def test_golfbox_client_login_failure(monkeypatch):
 
     class MockResponse:
         status_code = 200
+        url = "https://www.golfbox.no/login.asp"
         headers = {}
         cookies = requests.cookies.RequestsCookieJar()
+        text = ""
 
     class MockSession:
         cookies = requests.cookies.RequestsCookieJar()
 
         def post(self, *args, **kwargs):
+            return MockResponse()
+
+        def get(self, *args, **kwargs):
             return MockResponse()
 
     client = GolfBoxClient(username="test", password="wrong")


### PR DESCRIPTION
## Summary

Adds an MCP-backed data source for golf tee times so the scraper returns the **member view** instead of the guest view (845,-, real tournament blocks) rather than the AWS-IP guest view (795,-, false bookable tees).

- `mcp_client.py` — OAuth refresh-token grant + MCP streamable-HTTP transport, warm-container token cache, single 401 refresh+retry, RFC 8707 resource indicator, **auth circuit breaker** (aborts after 3 failures)
- `mcp_to_slots.py` — maps MCP slots to parser-format dict, extracts member price from `raw_label`
- `handler.py` — `GOLF_DATA_SOURCE` switch (`mcp` | `scrape`) + **DynamoDB run-lock serializing the MCP path**
- `facilities.py` — `mcp_slug` per golf club
- `scraper.py` — stale-session detection + cookie clearing (fallback-path hardening)
- `scripts/golfbox_mcp_oauth_setup.py` / `golfbox_mcp_poc.py` — one-time secret provisioning + standalone validation
- 82 golf tests pass

## 2026-05-21 incident — root cause CONFIRMED (and fixed)

The first live MCP run produced an `invalid_grant`/429 storm. Earlier hypothesis (access-token `aud` mismatch / Vardenlab IP-binding) is **disproven** by CloudWatch:

- Invocation A: refresh OK → `initialize` OK → **collected 874 slots** before any failure. 874 successful `tools/call`s from an AWS IP ⇒ token, audience, and IP are all fine.
- Invocation B started 60s later (concurrent), refreshed, rotating the shared refresh token.
- A's first failure is **1 second after B's refresh**: A re-refreshed with its now-stale token → Vardenlab's refresh-token **reuse detection revoked the whole token family** → both runs died → per-call "401 → re-refresh" retry amplified into the storm.

**Root cause: a concurrency race on the rotating refresh token.** Fix: since reserved concurrency=1 is unavailable (account Lambda limit = 10), the handler now takes a conditional-write **run-lock** on the golf-sessions table for the MCP path; a second concurrent invocation skips. TTL self-expires on crash. Scrape path is concurrency-safe and unaffected.

## Remaining work before flipping to `mcp`

- [x] Serialize golf-scraper MCP invocations (run-lock) — this PR
- [ ] Deploy `golf-scraper` from this branch (prod currently on `scrape`)
- [ ] Re-provision the secret — the RT family was revoked, so the stored token is dead. Run `scripts/golfbox_mcp_oauth_setup.py` (interactive, from a workstation)
- [ ] (Optional) grant the Lambda role `dynamodb:DeleteItem` on golf-sessions for clean lock release (release is best-effort; falls back to TTL otherwise)
- [ ] Flip `GOLF_DATA_SOURCE=mcp` and confirm `auth_failures=0, source=mcp` on one run

Production currently runs `GOLF_DATA_SOURCE=scrape` (guest view, functional). Full incident write-up in TROUBLESHOOTING.md.

## Test plan

- [x] `pytest tests/test_golf_mcp.py tests/test_golf_scraper.py` — 82 passed
- [ ] Re-provision secret + flip to `mcp`, confirm `auth_failures=0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)